### PR TITLE
colored board and tile animation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /target
+*log

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,6 +9,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c7d0618f0e0b7e8ff11427422b64564d5fb0be1940354bfe2e0529b18a9d9b8"
 
 [[package]]
+name = "approx"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cab112f0a86d568ea0e627cc1d6be74a1e9cd55214684db5561995f6dad897c6"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -56,6 +65,12 @@ checksum = "2ae1b35a484aa10e07fe0638d02301c5ad24de82d310ccbd2f3693da5f09bf1c"
 dependencies = [
  "winapi",
 ]
+
+[[package]]
+name = "fast-srgb8"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd2e7510819d6fbf51a5545c8f922716ecfb14df168a3242f7d33e0239efe6a1"
 
 [[package]]
 name = "futures"
@@ -207,6 +222,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-traits"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "578ede34cf02f8924ab9447f50c28075b4d3e5b269972345e7e0372b38c6cdcd"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
+name = "palette"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1641aee47803391405d0a1250e837d2336fdddd18b27f3ddb8c1d80ce8d7f43"
+dependencies = [
+ "approx",
+ "fast-srgb8",
+ "palette_derive",
+ "phf",
+]
+
+[[package]]
+name = "palette_derive"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c02bfa6b3ba8af5434fa0531bf5701f750d983d4260acd6867faca51cdc4484"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.18",
+]
+
+[[package]]
 name = "parking_lot"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -227,6 +274,48 @@ dependencies = [
  "redox_syscall",
  "smallvec",
  "windows-sys",
+]
+
+[[package]]
+name = "phf"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ade2d8b8f33c7333b51bcf0428d37e217e9f32192ae4772156f65063b8ce03dc"
+dependencies = [
+ "phf_macros",
+ "phf_shared",
+]
+
+[[package]]
+name = "phf_generator"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48e4cc64c2ad9ebe670cb8fd69dd50ae301650392e81c05f9bfcb2d5bdbc24b0"
+dependencies = [
+ "phf_shared",
+ "rand",
+]
+
+[[package]]
+name = "phf_macros"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3444646e286606587e49f3bcf1679b8cef1dc2c5ecc29ddacaffc305180d464b"
+dependencies = [
+ "phf_generator",
+ "phf_shared",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.18",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90fcb95eef784c2ac79119d1dd819e162b5da872ce6f3c3abe1e8ca1c082f72b"
+dependencies = [
+ "siphasher",
 ]
 
 [[package]]
@@ -382,6 +471,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "siphasher"
+version = "0.3.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7bd3e3206899af3f8b12af284fafc038cc1dc2b41d1b89dd17297221c5d225de"
+
+[[package]]
 name = "slab"
 version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -445,6 +540,7 @@ dependencies = [
  "anyhow",
  "boxy",
  "crossterm",
+ "palette",
  "rand",
  "rstest",
  "thiserror",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,15 @@
 version = 3
 
 [[package]]
+name = "aho-corasick"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43f6cb1bf222025340178f382c426f13757b2960e89779dfcb319c32542a5a41"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -30,10 +39,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
+name = "bitflags"
+version = "2.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "630be753d4e58660abd17930c71b647fe46c27ea6b63cc59e1e3851406972e42"
+
+[[package]]
 name = "boxy"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "29faef4e250b160ba2710303bdb2577286782dacca61a4a3613a68cf780eb53d"
+
+[[package]]
+name = "cc"
+version = "1.0.79"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50d30906286121d95be3d479533b458f87493b30a4b5f79a607db8f5d11aa91f"
 
 [[package]]
 name = "cfg-if"
@@ -47,7 +68,7 @@ version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a84cda67535339806297f1b331d6dd6320470d2a0fe65381e79ee9e156dd3d13"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "crossterm_winapi",
  "libc",
  "mio",
@@ -64,6 +85,40 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b"
 dependencies = [
  "winapi",
+]
+
+[[package]]
+name = "env_logger"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85cdab6a89accf66733ad5a1693a4dcced6aeff64602b634530dd73c1f3ee9f0"
+dependencies = [
+ "humantime",
+ "is-terminal",
+ "log",
+ "regex",
+ "termcolor",
+]
+
+[[package]]
+name = "errno"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4bcfec3a70f97c962c307b2d2c56e358cf1d00b558d74262b5f929ee8cc7e73a"
+dependencies = [
+ "errno-dragonfly",
+ "libc",
+ "windows-sys",
+]
+
+[[package]]
+name = "errno-dragonfly"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa68f1b12764fab894d2755d2518754e71b4fd80ecfb822714a1206c2aab39bf"
+dependencies = [
+ "cc",
+ "libc",
 ]
 
 [[package]]
@@ -188,10 +243,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "hermit-abi"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "443144c8cdadd93ebf52ddb4056d257f5b52c04d3c804e657d19eb73fc33668b"
+
+[[package]]
+name = "humantime"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
+
+[[package]]
+name = "is-terminal"
+version = "0.4.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb0889898416213fab133e1d33a0e5858a48177452750691bde3666d0fdbaf8b"
+dependencies = [
+ "hermit-abi",
+ "rustix",
+ "windows-sys",
+]
+
+[[package]]
 name = "libc"
 version = "0.2.147"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4668fb0ea861c1df094127ac5f1da3409a82116a4ba74fca2e58ef927159bb3"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09fc20d2ca12cb9f044c93e3bd6d32d523e6e2ec3db4f7b2939cd99026ecd3f0"
 
 [[package]]
 name = "lock_api"
@@ -396,8 +480,37 @@ version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "567664f262709473930a4bf9e51bf2ebf3348f2e748ccc50dea20646858f8f29"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
 ]
+
+[[package]]
+name = "regex"
+version = "1.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2eae68fc220f7cf2532e4494aded17545fce192d59cd996e0fe7887f4ceb575"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39354c10dd07468c2e73926b23bb9c2caca74c5501e38a35da70406f1d923310"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5ea92a5b6195c6ef2a0295ea818b312502c6fc94dde986c5553242e18fd4ce2"
 
 [[package]]
 name = "rstest"
@@ -432,6 +545,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
 dependencies = [
  "semver",
+]
+
+[[package]]
+name = "rustix"
+version = "0.38.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a962918ea88d644592894bc6dc55acc6c0956488adcebbfb6e273506b7fd6e5"
+dependencies = [
+ "bitflags 2.3.3",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys",
 ]
 
 [[package]]
@@ -520,6 +646,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "termcolor"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be55cf8942feac5c765c2c993422806843c9a9a45d4d5c407ad6dd2ea95eb9b6"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
 name = "thiserror"
 version = "1.0.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -546,6 +681,7 @@ dependencies = [
  "anyhow",
  "boxy",
  "crossterm",
+ "env_logger",
  "fern",
  "log",
  "palette",
@@ -581,6 +717,15 @@ name = "winapi-i686-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-util"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70ec6ce85bb158151cae5e5c87f95a8e97d2c0c4b001223f33a334e3ce5de178"
+dependencies = [
+ "winapi",
+]
 
 [[package]]
 name = "winapi-x86_64-pc-windows-gnu"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -59,9 +59,9 @@ dependencies = [
 
 [[package]]
 name = "crossterm_winapi"
-version = "0.9.0"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ae1b35a484aa10e07fe0638d02301c5ad24de82d310ccbd2f3693da5f09bf1c"
+checksum = "acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b"
 dependencies = [
  "winapi",
 ]
@@ -71,6 +71,15 @@ name = "fast-srgb8"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd2e7510819d6fbf51a5545c8f922716ecfb14df168a3242f7d33e0239efe6a1"
+
+[[package]]
+name = "fern"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9f0c14694cbd524c8720dd69b0e3179344f04ebb5f90f2e4a440c6ea3b2f1ee"
+dependencies = [
+ "log",
+]
 
 [[package]]
 name = "futures"
@@ -128,7 +137,7 @@ checksum = "89ca545a94061b6365f2c7355b4b32bd20df3ff95f02da9329b34ccc3bd6ee72"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.18",
+ "syn 2.0.23",
 ]
 
 [[package]]
@@ -169,9 +178,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.9"
+version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c85e1d9ab2eadba7e5040d4e09cbd6d072b76a557ad64e797c2cb9d4da21d7e4"
+checksum = "be4136b2a15dd319360be1c07d9933517ccf0be8f16bf62a3bee4f0d618df427"
 dependencies = [
  "cfg-if",
  "libc",
@@ -180,15 +189,15 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.140"
+version = "0.2.147"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99227334921fae1a979cf0bfdfcc6b3e5ce376ef57e16fb6fb3ea2ed6095f80c"
+checksum = "b4668fb0ea861c1df094127ac5f1da3409a82116a4ba74fca2e58ef927159bb3"
 
 [[package]]
 name = "lock_api"
-version = "0.4.9"
+version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "435011366fe56583b16cf956f9df0095b405b82d76425bc8981c0e22e60ec4df"
+checksum = "c1cc9717a20b1bb222f333e6a92fd32f7d8a18ddc5a3191a11af45dcbf4dcd16"
 dependencies = [
  "autocfg",
  "scopeguard",
@@ -196,12 +205,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.17"
+version = "0.4.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abb12e687cfb44aa40f41fc3978ef76448f9b6038cad6aef4259d3c095a2382e"
-dependencies = [
- "cfg-if",
-]
+checksum = "b06a4cde4c0f271a446782e3eff8de789548ce57dbc8eca9292c27f4a42004b4"
 
 [[package]]
 name = "memchr"
@@ -211,9 +217,9 @@ checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
 
 [[package]]
 name = "mio"
-version = "0.8.6"
+version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b9d9a46eff5b4ff64b45a9e316a6d1e0bc719ef429cbec4dc630684212bfdf9"
+checksum = "927a765cd3fc26206e66b296465fa9d3e5ab003e651c1b3c060e7956d96b19d2"
 dependencies = [
  "libc",
  "log",
@@ -250,7 +256,7 @@ checksum = "3c02bfa6b3ba8af5434fa0531bf5701f750d983d4260acd6867faca51cdc4484"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.18",
+ "syn 2.0.23",
 ]
 
 [[package]]
@@ -265,15 +271,15 @@ dependencies = [
 
 [[package]]
 name = "parking_lot_core"
-version = "0.9.7"
+version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9069cbb9f99e3a5083476ccb29ceb1de18b9118cafa53e90c9551235de2b9521"
+checksum = "93f00c865fe7cabf650081affecd3871070f26767e7b2070a3ffae14c654b447"
 dependencies = [
  "cfg-if",
  "libc",
  "redox_syscall",
  "smallvec",
- "windows-sys",
+ "windows-targets",
 ]
 
 [[package]]
@@ -306,7 +312,7 @@ dependencies = [
  "phf_shared",
  "proc-macro2",
  "quote",
- "syn 2.0.18",
+ "syn 2.0.23",
 ]
 
 [[package]]
@@ -320,9 +326,9 @@ dependencies = [
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.9"
+version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0a7ae3ac2f1173085d398531c705756c94a4c56843785df85a60c1a0afac116"
+checksum = "4c40d25201921e5ff0c862a505c6557ea88568a4e3ace775ab55e93f2f4f9d57"
 
 [[package]]
 name = "pin-utils"
@@ -338,18 +344,18 @@ checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.59"
+version = "1.0.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6aeca18b86b413c660b781aa319e4e2648a3e6f9eadc9b47e9038e6fe9f3451b"
+checksum = "7b368fba921b0dce7e60f5e04ec15e565b3303972b42bcfde1d0713b881959eb"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.28"
+version = "1.0.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b9ab9c7eadfd8df19006f1cf1a4aed13540ed5cbc047010ece5826e10825488"
+checksum = "573015e8ab27661678357f27dc26460738fd2b6c86e46f386fde94cb5d913105"
 dependencies = [
  "proc-macro2",
 ]
@@ -386,9 +392,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.2.16"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a"
+checksum = "567664f262709473930a4bf9e51bf2ebf3348f2e748ccc50dea20646858f8f29"
 dependencies = [
  "bitflags",
 ]
@@ -504,9 +510,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.18"
+version = "2.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32d41677bcbe24c20c52e7c70b0d8db04134c5d1066bf98662e2871ad200ea3e"
+checksum = "59fb7d6d8281a51045d62b8eb3a7d1ce347b76f312af50cd3dc0af39c87c1737"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -515,22 +521,22 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.40"
+version = "1.0.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "978c9a314bd8dc99be594bc3c175faaa9794be04a5a5e153caba6915336cebac"
+checksum = "c16a64ba9387ef3fdae4f9c1a7f07a0997fce91985c0336f1ddc1822b3b37802"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.40"
+version = "1.0.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9456a42c5b0d803c8cd86e73dd7cc9edd429499f37a3550d286d5e86720569f"
+checksum = "d14928354b01c4d6a4f0e549069adef399a284e7995c7ccca94e8a07a5346c59"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.18",
+ "syn 2.0.23",
 ]
 
 [[package]]
@@ -540,6 +546,8 @@ dependencies = [
  "anyhow",
  "boxy",
  "crossterm",
+ "fern",
+ "log",
  "palette",
  "rand",
  "rstest",
@@ -548,9 +556,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.9"
+version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b15811caf2415fb889178633e7724bad2509101cde276048e013b9def5e51fa0"
+checksum = "22049a19f4a68748a168c0fc439f9516686aa045927ff767eca0a85101fb6e73"
 
 [[package]]
 name = "wasi"
@@ -582,18 +590,18 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-sys"
-version = "0.45.0"
+version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
+checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
 dependencies = [
  "windows-targets",
 ]
 
 [[package]]
 name = "windows-targets"
-version = "0.42.2"
+version = "0.48.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
+checksum = "05d4b17490f70499f20b9e791dcf6a299785ce8af4d709018206dc5b4953e95f"
 dependencies = [
  "windows_aarch64_gnullvm",
  "windows_aarch64_msvc",
@@ -606,42 +614,42 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.42.2"
+version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
+checksum = "91ae572e1b79dba883e0d315474df7305d12f569b400fcf90581b06062f7e1bc"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.42.2"
+version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
+checksum = "b2ef27e0d7bdfcfc7b868b317c1d32c641a6fe4629c171b8928c7b08d98d7cf3"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.42.2"
+version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
+checksum = "622a1962a7db830d6fd0a69683c80a18fda201879f0f447f065a3b7467daa241"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.42.2"
+version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
+checksum = "4542c6e364ce21bf45d69fdd2a8e455fa38d316158cfd43b3ac1c5b1b19f8e00"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.42.2"
+version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
+checksum = "ca2b8a661f7628cbd23440e50b05d705db3686f894fc9580820623656af974b1"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.42.2"
+version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
+checksum = "7896dbc1f41e08872e9d5e8f8baa8fdd2677f29468c4e156210174edc7f7b953"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.42.2"
+version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
+checksum = "1a515f5799fe4961cb532f983ce2b23082366b898e52ffbce459c86f67c8378a"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,3 +26,4 @@ palette = "0.7"
 
 rstest = "0.17.0"
 rand = { version = "0.8.5", features = ["small_rng"] }
+env_logger = "*"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,8 @@ boxy = "0.1"
 rand = "0.8.5"
 thiserror = "1.0"
 anyhow = "1.0"
+log = "0.4"
+fern = "0.6"
 
 palette = "0.7"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,8 @@ rand = "0.8.5"
 thiserror = "1.0"
 anyhow = "1.0"
 
+palette = "0.7"
+
 [dev-dependencies]
 
 rstest = "0.17.0"

--- a/src/engine/board.rs
+++ b/src/engine/board.rs
@@ -51,10 +51,8 @@ impl Board {
         (4, 4)
     }
 
-    // used in the tui48 module's test suite to more deterministically set the desired state of
-    // play for the board. underscore-prefixed in order to prevent compiler warnings about dead
-    // code
-    pub(crate) fn _set_initial_round(&mut self, round: Round) {
+    #[cfg(test)]
+    pub(crate) fn set_initial_round(&mut self, round: Round) {
         let mut v = Vec::with_capacity(1);
         v.push(round);
         self.rounds = v;

--- a/src/engine/board.rs
+++ b/src/engine/board.rs
@@ -1,17 +1,7 @@
 use rand::rngs::ThreadRng;
 
 use super::round::{AnimationHint, Round, Score};
-
-/// Direction represents the direction indicated by the player.
-#[derive(Clone, Debug, Default)]
-pub(crate) enum Direction {
-    #[default]
-    Left,
-    Right,
-    Up,
-    Down,
-}
-
+use crate::tui::geometry::Direction;
 /// Board represents a 2048 board that keeps track of the history of its game states.
 pub(crate) struct Board {
     rng: ThreadRng,

--- a/src/engine/board.rs
+++ b/src/engine/board.rs
@@ -1,19 +1,20 @@
-use rand::rngs::ThreadRng;
+use rand::RngCore;
 
 use super::round::{AnimationHint, Round, Score};
 use crate::tui::geometry::Direction;
+
 /// Board represents a 2048 board that keeps track of the history of its game states.
 pub(crate) struct Board {
-    rng: ThreadRng,
+    rng: Box<dyn RngCore>,
     rounds: Vec<Round>,
 }
 
 impl Board {
     /// Initialize new board using the given random number generator.
-    pub(crate) fn new(mut rng: ThreadRng) -> Self {
+    pub(crate) fn new(mut rng: impl RngCore + 'static) -> Self {
         let mut rounds = Vec::with_capacity(2000);
         rounds.push(Round::random(&mut rng));
-        Self { rng, rounds }
+        Self { rng: Box::new(rng), rounds }
     }
 
     pub(crate) fn score(&self) -> Score {

--- a/src/engine/board.rs
+++ b/src/engine/board.rs
@@ -14,7 +14,10 @@ impl Board {
     pub(crate) fn new(mut rng: impl RngCore + 'static) -> Self {
         let mut rounds = Vec::with_capacity(2000);
         rounds.push(Round::random(&mut rng));
-        Self { rng: Box::new(rng), rounds }
+        Self {
+            rng: Box::new(rng),
+            rounds,
+        }
     }
 
     pub(crate) fn score(&self) -> Score {
@@ -38,7 +41,10 @@ impl Board {
     }
 
     pub(crate) fn current(&self) -> Round {
-        self.rounds.last().expect("a board must always have at least one round").clone()
+        self.rounds
+            .last()
+            .expect("a board must always have at least one round")
+            .clone()
     }
 
     pub(crate) fn previous(&self) -> Option<Round> {

--- a/src/engine/board.rs
+++ b/src/engine/board.rs
@@ -36,8 +36,12 @@ impl Board {
         hint
     }
 
-    pub(crate) fn current(&self) -> &Round {
-        self.rounds.last().expect("a board must always have at least one round")
+    pub(crate) fn current(&self) -> Round {
+        self.rounds.last().expect("a board must always have at least one round").clone()
+    }
+
+    pub(crate) fn previous(&self) -> Option<Round> {
+        self.rounds.iter().rev().nth(2).cloned()
     }
 
     pub(crate) fn dimensions(&self) -> (usize, usize) {

--- a/src/engine/board.rs
+++ b/src/engine/board.rs
@@ -54,4 +54,10 @@ impl Board {
     pub(crate) fn dimensions(&self) -> (usize, usize) {
         (4, 4)
     }
+
+    pub(crate) fn set_initial_round(&mut self, round: Round) {
+        let mut v = Vec::with_capacity(1);
+        v.push(round);
+        self.rounds = v;
+    }
 }

--- a/src/engine/board.rs
+++ b/src/engine/board.rs
@@ -47,15 +47,14 @@ impl Board {
             .clone()
     }
 
-    pub(crate) fn previous(&self) -> Option<Round> {
-        self.rounds.iter().rev().nth(2).cloned()
-    }
-
     pub(crate) fn dimensions(&self) -> (usize, usize) {
         (4, 4)
     }
 
-    pub(crate) fn set_initial_round(&mut self, round: Round) {
+    // used in the tui48 module's test suite to more deterministically set the desired state of
+    // play for the board. underscore-prefixed in order to prevent compiler warnings about dead
+    // code
+    pub(crate) fn _set_initial_round(&mut self, round: Round) {
         let mut v = Vec::with_capacity(1);
         v.push(round);
         self.rounds = v;

--- a/src/engine/round.rs
+++ b/src/engine/round.rs
@@ -38,6 +38,7 @@ impl AnimationHint {
             changed: false,
         }
     }
+
     fn set(&mut self, idx: &Idx, value: Hint) {
         self.changed = true;
         self.hint.push((idx.clone(), value));

--- a/src/engine/round.rs
+++ b/src/engine/round.rs
@@ -9,13 +9,20 @@ use super::board::Direction;
 pub(crate) struct Idx(pub(crate) usize, pub(crate) usize);
 
 #[derive(Default)]
+pub(crate) enum Hint {
+    #[default]
+    None,
+    ToIdx(Idx),
+}
+
+#[derive(Default)]
 pub(crate) struct AnimationHint {
-    hint: [[Option<Idx>; 4]; 4],
+    hint: [[Option<Hint>; 4]; 4],
     changed: bool,
 }
 
 impl AnimationHint {
-    fn get_mut(&mut self, idx: &Idx) -> &mut Option<Idx> {
+    fn get_mut(&mut self, idx: &Idx) -> &mut Option<Hint> {
         self.hint
             .get_mut(idx.1)
             .expect(format!("invalid y coordinate {}", idx.1).as_str())
@@ -23,7 +30,7 @@ impl AnimationHint {
             .expect(format!("invalid x coordinate {}", idx.0).as_str())
     }
 
-    fn set(&mut self, idx: &Idx, value: Idx) {
+    fn set(&mut self, idx: &Idx, value: Hint) {
         self.changed = true;
         let rf = self.get_mut(idx);
         *rf = Some(value);
@@ -106,7 +113,7 @@ impl Round {
                 if pivot == 0 {
                     self.set(pivot_idx, cmp);
                     self.set(cmp_idx, 0);
-                    hint.set(cmp_idx, pivot_idx.clone());
+                    hint.set(cmp_idx, Hint::ToIdx(pivot_idx.clone()));
                     continue;
                 }
                 // if the pivot element and the cmp element are equal then they must be combined;
@@ -115,7 +122,7 @@ impl Round {
                     self.score += cmp;
                     self.set(pivot_idx, pivot + cmp);
                     self.set(cmp_idx, 0);
-                    hint.set(cmp_idx, pivot_idx.clone());
+                    hint.set(cmp_idx, Hint::ToIdx(pivot_idx.clone()));
                 }
                 if let Some(idx) = pivot_iter.next() {
                     pivot_idx = idx;

--- a/src/engine/round.rs
+++ b/src/engine/round.rs
@@ -79,16 +79,6 @@ impl AnimationHint {
     pub(crate) fn hints(&self) -> Vec<(Idx, Hint)> {
         self.hint.clone()
     }
-
-    pub(crate) fn remove(&mut self, idx: &Idx, hint: &Hint) {
-        let mut remove_idx = 0usize;
-        for (hint_idx, (i, h)) in self.hint.iter().enumerate() {
-            if *i == *idx && *h == *hint {
-                remove_idx = hint_idx;
-            }
-        }
-        let _ = self.hint.remove(remove_idx);
-    }
 }
 
 pub(crate) type Card = u16;
@@ -223,7 +213,9 @@ impl Round {
         *rf = value;
     }
 
-    pub(crate) fn set_value(&mut self, idx: &Idx, value: u16) {
+    // used in tui48 test suite to set the value of a given round index. underscore-prefixed to
+    // avoid build warnings while still allowing the method to be used in other modules' tests.
+    pub(crate) fn _set_value(&mut self, idx: &Idx, value: u16) {
         let rf = self.get_mut(idx);
         *rf = value;
     }
@@ -365,7 +357,7 @@ mod test {
         ] {
             let mut shifted = initial.clone();
             let mut rng = rng();
-            let hint = shifted.shift(&mut rng, &direction);
+            let _ = shifted.shift(&mut rng, &direction);
             assert_eq!(initial, shifted, "shifting {:?}", direction);
             assert_eq!(initial.score, shifted.score, "shifting {:?}", direction);
         }
@@ -434,7 +426,7 @@ mod test {
 
         let mut shifted = initial.clone();
         let mut rng = rng();
-        let hint = shifted.shift(&mut rng, &direction);
+        let _ = shifted.shift(&mut rng, &direction);
         assert_eq!(shifted, expected, "shifting {:?}", direction);
     }
 
@@ -487,7 +479,7 @@ mod test {
     fn combine(#[case] direction: Direction, #[case] initial: Round, #[case] expected: Round) {
         let mut shifted = initial.clone();
         let mut rng = rng();
-        let hint = shifted.shift(&mut rng, &direction);
+        let _ = shifted.shift(&mut rng, &direction);
         assert_eq!(shifted, expected, "shifting {:?}", direction);
     }
 }

--- a/src/engine/round.rs
+++ b/src/engine/round.rs
@@ -13,6 +13,7 @@ pub(crate) enum Hint {
     #[default]
     None,
     ToIdx(Idx),
+    NewFrom(Direction),
 }
 
 #[derive(Default)]
@@ -141,6 +142,7 @@ impl Round {
                 .expect("all rows are populated and at least one row has changed");
             let new_value = NEW_CARD_CHOICES[self.new_tile_weighted_index.sample(&mut rng)];
             self.set(idx, new_value);
+            hint.set(idx, Hint::NewFrom(direction.clone()));
             Some(hint)
         } else {
             None

--- a/src/engine/round.rs
+++ b/src/engine/round.rs
@@ -22,7 +22,7 @@ impl Idx {
 pub(crate) enum Hint {
     ToIdx(Idx),
     NewValueToIdx(u16, Idx),
-    NewFrom(u16, Direction),
+    NewTile(u16, Direction),
 }
 
 #[derive(Default, PartialEq)]
@@ -163,7 +163,7 @@ impl Round {
                 .expect("all rows are populated and at least one row has changed");
             let new_value = NEW_CARD_CHOICES[self.new_tile_weighted_index.sample(&mut rng)];
             self.set(idx, new_value);
-            hint.set(idx, Hint::NewFrom(new_value, direction.clone()));
+            hint.set(idx, Hint::NewTile(new_value, direction.clone()));
             Some(hint)
         } else {
             None

--- a/src/engine/round.rs
+++ b/src/engine/round.rs
@@ -5,7 +5,7 @@ use rand::Rng;
 
 use crate::tui::geometry::Direction;
 
-#[derive(Clone, Default, PartialEq)]
+#[derive(Clone, Debug, Default, PartialEq)]
 pub(crate) struct Idx(pub(crate) usize, pub(crate) usize);
 
 impl Idx {

--- a/src/engine/round.rs
+++ b/src/engine/round.rs
@@ -213,9 +213,8 @@ impl Round {
         *rf = value;
     }
 
-    // used in tui48 test suite to set the value of a given round index. underscore-prefixed to
-    // avoid build warnings while still allowing the method to be used in other modules' tests.
-    pub(crate) fn _set_value(&mut self, idx: &Idx, value: u16) {
+    #[cfg(test)]
+    pub(crate) fn set_value(&mut self, idx: &Idx, value: u16) {
         let rf = self.get_mut(idx);
         *rf = value;
     }

--- a/src/engine/round.rs
+++ b/src/engine/round.rs
@@ -8,7 +8,17 @@ use crate::tui::geometry::Direction;
 #[derive(Clone, Default)]
 pub(crate) struct Idx(pub(crate) usize, pub(crate) usize);
 
-#[derive(Default)]
+impl Idx {
+    pub(crate) fn x(&self) -> usize {
+        self.0
+    }
+
+    pub(crate) fn y(&self) -> usize {
+        self.1
+    }
+}
+
+#[derive(Clone, Default)]
 pub(crate) enum Hint {
     #[default]
     None,
@@ -29,7 +39,7 @@ impl AnimationHint {
     }
 
     pub(crate) fn hints(&self) -> Vec<(Idx, Hint)> {
-        Vec::new()
+        self.hint.clone()
     }
 }
 

--- a/src/engine/round.rs
+++ b/src/engine/round.rs
@@ -35,8 +35,12 @@ impl std::fmt::Display for Hint {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             Self::ToIdx(idx) => write!(f, "Hint::ToIdx({0})", idx),
-            Self::NewValueToIdx(value, idx) => write!(f, "Hint::NewValueToIdx({0}, {1})", value, idx),
-            Self::NewTile(value, direction) => write!(f, "Hint::NewTile({0}, {1})", value, direction),
+            Self::NewValueToIdx(value, idx) => {
+                write!(f, "Hint::NewValueToIdx({0}, {1})", value, idx)
+            }
+            Self::NewTile(value, direction) => {
+                write!(f, "Hint::NewTile({0}, {1})", value, direction)
+            }
         }
     }
 }
@@ -49,7 +53,7 @@ pub(crate) struct AnimationHint {
 
 impl std::fmt::Display for AnimationHint {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        if self.hint.len() > 0  {
+        if self.hint.len() > 0 {
             write!(f, "\n")?;
         }
         for (idx, hint) in &self.hint {

--- a/src/engine/round.rs
+++ b/src/engine/round.rs
@@ -18,23 +18,18 @@ pub(crate) enum Hint {
 
 #[derive(Default)]
 pub(crate) struct AnimationHint {
-    hint: [[Option<Hint>; 4]; 4],
+    hint: Vec<(Idx, Hint)>,
     changed: bool,
 }
 
 impl AnimationHint {
-    fn get_mut(&mut self, idx: &Idx) -> &mut Option<Hint> {
-        self.hint
-            .get_mut(idx.1)
-            .expect(format!("invalid y coordinate {}", idx.1).as_str())
-            .get_mut(idx.0)
-            .expect(format!("invalid x coordinate {}", idx.0).as_str())
-    }
-
     fn set(&mut self, idx: &Idx, value: Hint) {
         self.changed = true;
-        let rf = self.get_mut(idx);
-        *rf = Some(value);
+        self.hint.push((idx.clone(), value));
+    }
+
+    pub(crate) fn hints(&self) -> Vec<(Idx, Hint)> {
+        Vec::new()
     }
 }
 

--- a/src/engine/round.rs
+++ b/src/engine/round.rs
@@ -5,7 +5,7 @@ use rand::Rng;
 
 use crate::tui::geometry::Direction;
 
-#[derive(Clone, Default)]
+#[derive(Clone, Default, PartialEq)]
 pub(crate) struct Idx(pub(crate) usize, pub(crate) usize);
 
 impl Idx {
@@ -18,14 +18,14 @@ impl Idx {
     }
 }
 
-#[derive(Clone)]
+#[derive(Clone, PartialEq)]
 pub(crate) enum Hint {
     ToIdx(Idx),
     NewValueToIdx(u16, Idx),
     NewFrom(u16, Direction),
 }
 
-#[derive(Default)]
+#[derive(Default, PartialEq)]
 pub(crate) struct AnimationHint {
     hint: Vec<(Idx, Hint)>,
     changed: bool,
@@ -45,6 +45,16 @@ impl AnimationHint {
 
     pub(crate) fn hints(&self) -> Vec<(Idx, Hint)> {
         self.hint.clone()
+    }
+
+    pub(crate) fn remove(&mut self, idx: &Idx, hint: &Hint) {
+        let mut remove_idx = 0usize;
+        for (hint_idx, (i, h)) in self.hint.iter().enumerate() {
+            if *i == *idx && *h == *hint {
+                remove_idx = hint_idx;
+            }
+        }
+        let _ = self.hint.remove(remove_idx);
     }
 }
 

--- a/src/engine/round.rs
+++ b/src/engine/round.rs
@@ -281,9 +281,9 @@ impl Indices {
 
 #[cfg(test)]
 mod test {
-    use rstest::*;
     use rand::rngs::SmallRng;
     use rand::SeedableRng;
+    use rstest::*;
 
     use super::*;
     fn rng() -> SmallRng {

--- a/src/engine/round.rs
+++ b/src/engine/round.rs
@@ -5,7 +5,7 @@ use rand::Rng;
 
 use crate::tui::geometry::Direction;
 
-#[derive(Clone, Debug, Default, PartialEq)]
+#[derive(Clone, Debug, Default, Eq, Hash, PartialEq)]
 pub(crate) struct Idx(pub(crate) usize, pub(crate) usize);
 
 impl std::fmt::Display for Idx {
@@ -219,6 +219,11 @@ impl Round {
     }
 
     fn set(&mut self, idx: &Idx, value: Card) {
+        let rf = self.get_mut(idx);
+        *rf = value;
+    }
+
+    pub(crate) fn set_value(&mut self, idx: &Idx, value: u16) {
         let rf = self.get_mut(idx);
         *rf = value;
     }

--- a/src/engine/round.rs
+++ b/src/engine/round.rs
@@ -8,6 +8,12 @@ use crate::tui::geometry::Direction;
 #[derive(Clone, Debug, Default, PartialEq)]
 pub(crate) struct Idx(pub(crate) usize, pub(crate) usize);
 
+impl std::fmt::Display for Idx {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "ridx({0},{1})", self.0, self.1)
+    }
+}
+
 impl Idx {
     pub(crate) fn x(&self) -> usize {
         self.0
@@ -25,10 +31,32 @@ pub(crate) enum Hint {
     NewTile(u16, Direction),
 }
 
+impl std::fmt::Display for Hint {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::ToIdx(idx) => write!(f, "Hint::ToIdx({0})", idx),
+            Self::NewValueToIdx(value, idx) => write!(f, "Hint::NewValueToIdx({0}, {1})", value, idx),
+            Self::NewTile(value, direction) => write!(f, "Hint::NewTile({0}, {1})", value, direction),
+        }
+    }
+}
+
 #[derive(Default, PartialEq)]
 pub(crate) struct AnimationHint {
     hint: Vec<(Idx, Hint)>,
     changed: bool,
+}
+
+impl std::fmt::Display for AnimationHint {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        if self.hint.len() > 0  {
+            write!(f, "\n")?;
+        }
+        for (idx, hint) in &self.hint {
+            write!(f, "  {0} - {1}\n", idx, hint)?;
+        }
+        Ok(())
+    }
 }
 
 impl AnimationHint {

--- a/src/engine/round.rs
+++ b/src/engine/round.rs
@@ -3,7 +3,7 @@ use rand::distributions::WeightedIndex;
 use rand::seq::IteratorRandom;
 use rand::Rng;
 
-use super::board::Direction;
+use crate::tui::geometry::Direction;
 
 #[derive(Clone, Default)]
 pub(crate) struct Idx(pub(crate) usize, pub(crate) usize);

--- a/src/engine/round.rs
+++ b/src/engine/round.rs
@@ -85,26 +85,6 @@ impl Round {
             .get(idx.0)
             .expect(format!("invalid x coordinate {}", idx.0).as_str())
     }
-}
-
-// private methods
-impl Round {
-    fn iter_mut(&self, direction: Direction) -> Indices {
-        Indices::new(self, direction)
-    }
-
-    fn get_mut(&mut self, idx: &Idx) -> &mut Card {
-        self.slots
-            .get_mut(idx.1)
-            .expect(format!("invalid y coordinate {}", idx.1).as_str())
-            .get_mut(idx.0)
-            .expect(format!("invalid x coordinate {}", idx.0).as_str())
-    }
-
-    fn set(&mut self, idx: &Idx, value: Card) {
-        let rf = self.get_mut(idx);
-        *rf = value;
-    }
 
     pub fn shift<T: Rng>(&mut self, mut rng: T, direction: &Direction) -> Option<AnimationHint> {
         let mut hint = AnimationHint::default();
@@ -158,6 +138,26 @@ impl Round {
         } else {
             None
         }
+    }
+}
+
+// private methods
+impl Round {
+    fn iter_mut(&self, direction: Direction) -> Indices {
+        Indices::new(self, direction)
+    }
+
+    fn get_mut(&mut self, idx: &Idx) -> &mut Card {
+        self.slots
+            .get_mut(idx.1)
+            .expect(format!("invalid y coordinate {}", idx.1).as_str())
+            .get_mut(idx.0)
+            .expect(format!("invalid x coordinate {}", idx.0).as_str())
+    }
+
+    fn set(&mut self, idx: &Idx, value: Card) {
+        let rf = self.get_mut(idx);
+        *rf = value;
     }
 }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -36,7 +36,7 @@ pub(crate) enum Error {
     CannotConvertToStatic,
 
     #[error("cannot convert {idx:?} to sliding tile slot")]
-    CannotConvertToSliding { idx: crate::engine::round::Idx },
+    CannotConvertToSliding { idx: Option<crate::engine::round::Idx> },
 
     #[error("cannot convert slot to new sliding tile slot")]
     CannotConvertToNewSlidingTileSlot,

--- a/src/error.rs
+++ b/src/error.rs
@@ -26,12 +26,15 @@ pub(crate) enum Error {
     #[error("default colors already set")]
     DefaultColorsAlreadySet,
 
-    #[error("unable to retrieve drawbuffer: {reason:?}")]
-    UnableToRetrieveDrawBuffer { reason: String },
-
-    #[error("new tile missing during animation")]
-    NewTileMissing,
+    #[error("unable to retrieve drawbuffer: {context:?}")]
+    UnableToRetrieveSlot { context: String },
 
     #[error("unexpected strong reference in smart pointer")]
     UnexpectedStrongReference,
+
+    #[error("cannot convert slot to sliding tile slot")]
+    CannotConvertToSliding,
+
+    #[error("cannot convert slot to new sliding tile slot")]
+    CannotConvertToNewSlidingTileSlot,
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -28,4 +28,10 @@ pub(crate) enum Error {
 
     #[error("unable to retrieve drawbuffer: {reason:?}")]
     UnableToRetrieveDrawBuffer { reason: String },
+
+    #[error("new tile missing during animation")]
+    NewTileMissing,
+
+    #[error("unexpected strong reference in smart pointer")]
+    UnexpectedStrongReference,
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -25,4 +25,7 @@ pub(crate) enum Error {
 
     #[error("default colors already set")]
     DefaultColorsAlreadySet,
+
+    #[error("unable to retrieve drawbuffer")]
+    UnableToRetrieveDrawBuffer,
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -29,17 +29,11 @@ pub(crate) enum Error {
     #[error("unable to retrieve drawbuffer: {context:?}")]
     UnableToRetrieveSlot { context: String },
 
-    #[error("unexpected strong reference in smart pointer")]
-    UnexpectedStrongReference,
-
     #[error("cannot convert slot to static tile slot")]
     CannotConvertToStatic,
 
     #[error("cannot convert {idx:?} to sliding tile slot")]
     CannotConvertToSliding { idx: Option<crate::engine::round::Idx> },
-
-    #[error("cannot convert slot to new sliding tile slot")]
-    CannotConvertToNewSlidingTileSlot,
 
     #[error("terminal too small, required minimum size {0} x {1}")]
     TerminalTooSmall(usize, usize),

--- a/src/error.rs
+++ b/src/error.rs
@@ -26,9 +26,6 @@ pub(crate) enum Error {
         source: crate::tui::error::TuiError,
     },
 
-    #[error("default colors already set")]
-    DefaultColorsAlreadySet,
-
     #[error("unable to retrieve drawbuffer: {context:?}")]
     UnableToRetrieveSlot { context: String },
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -43,4 +43,7 @@ pub(crate) enum Error {
 
     #[error("cannot convert slot to new sliding tile slot")]
     CannotConvertToNewSlidingTileSlot,
+
+    #[error("terminal too small, required minimum size {0} x {1}")]
+    TerminalTooSmall(usize, usize),
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -26,6 +26,6 @@ pub(crate) enum Error {
     #[error("default colors already set")]
     DefaultColorsAlreadySet,
 
-    #[error("unable to retrieve drawbuffer")]
-    UnableToRetrieveDrawBuffer,
+    #[error("unable to retrieve drawbuffer: {reason:?}")]
+    UnableToRetrieveDrawBuffer { reason: String },
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -22,4 +22,7 @@ pub(crate) enum Error {
         #[from]
         source: crate::tui::error::TuiError,
     },
+
+    #[error("default colors already set")]
+    DefaultColorsAlreadySet,
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -11,6 +11,9 @@ pub(crate) enum Error {
     #[error("io error")]
     StdIOError(#[from] std::io::Error),
 
+    #[error("log error")]
+    LogError(#[from] log::SetLoggerError),
+
     #[error("{source:?}")]
     AnyhowError {
         #[from]

--- a/src/error.rs
+++ b/src/error.rs
@@ -32,6 +32,9 @@ pub(crate) enum Error {
     #[error("unexpected strong reference in smart pointer")]
     UnexpectedStrongReference,
 
+    #[error("cannot convert slot to static tile slot")]
+    CannotConvertToStatic,
+
     #[error("cannot convert slot to sliding tile slot")]
     CannotConvertToSliding,
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -35,8 +35,8 @@ pub(crate) enum Error {
     #[error("cannot convert slot to static tile slot")]
     CannotConvertToStatic,
 
-    #[error("cannot convert slot to sliding tile slot")]
-    CannotConvertToSliding,
+    #[error("cannot convert {idx:?} to sliding tile slot")]
+    CannotConvertToSliding { idx: crate::engine::round::Idx },
 
     #[error("cannot convert slot to new sliding tile slot")]
     CannotConvertToNewSlidingTileSlot,

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,7 +9,7 @@ mod tui48;
 
 use engine::board::Board;
 use error::Result;
-use tui48::Tui48;
+use tui48::{init, Tui48};
 use tui::crossterm::{Crossterm, CrosstermEvents};
 
 fn main() -> Result<()> {
@@ -19,6 +19,8 @@ fn main() -> Result<()> {
     let renderer = Crossterm::new(Box::new(w))?;
     let event_source = CrosstermEvents::default();
     let tui48 = Tui48::new(board, renderer, event_source)?;
+
+    init()?;
 
     Ok(tui48.run()?)
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,17 +1,17 @@
-use std::io::stdout;
 use std::error::Error;
+use std::io::stdout;
 
-use rand::thread_rng;
 use anyhow::Result;
+use rand::thread_rng;
 
-mod error;
 mod engine;
+mod error;
 mod tui;
 mod tui48;
 
 use engine::board::Board;
-use tui48::{init, Tui48};
 use tui::crossterm::{Crossterm, CrosstermEvents};
+use tui48::{init, Tui48};
 
 fn main() -> Result<()> {
     let rng = thread_rng();
@@ -20,6 +20,20 @@ fn main() -> Result<()> {
     let renderer = Crossterm::new(Box::new(w))?;
     let event_source = CrosstermEvents::default();
     let tui48 = Tui48::new(board, renderer, event_source)?;
+    fern::Dispatch::new()
+        .format(|out, message, record| {
+            out.finish(format_args!(
+                "[{} {}] {}",
+                record.level(),
+                record.target(),
+                message,
+            ))
+        })
+        .level(log::LevelFilter::Trace)
+        .chain(fern::log_file("./output.log")?)
+        .apply()?;
+
+    log::info!("log test");
 
     init()?;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,3 @@
-use std::error::Error;
 use std::io::stdout;
 
 use anyhow::Result;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,8 @@
 use std::io::stdout;
+use std::error::Error;
 
 use rand::thread_rng;
+use anyhow::Result;
 
 mod error;
 mod engine;
@@ -8,7 +10,6 @@ mod tui;
 mod tui48;
 
 use engine::board::Board;
-use error::Result;
 use tui48::{init, Tui48};
 use tui::crossterm::{Crossterm, CrosstermEvents};
 
@@ -22,5 +23,13 @@ fn main() -> Result<()> {
 
     init()?;
 
-    Ok(tui48.run()?)
+    tui48.run()?;
+    // match tui48.run() {
+    //     Err(e) => {
+    //         eprintln!("{}", e);
+    //     },
+    //     Ok(_) => eprintln!("everything okay!"),
+    // }
+
+    Ok(())
 }

--- a/src/tui/canvas.rs
+++ b/src/tui/canvas.rs
@@ -36,7 +36,7 @@ impl CanvasInner {
                 let canvas_idx = Idx(x, y, r.0 .2);
                 let cell = cellstack.acquire(canvas_idx.z());
                 let tuxel = match cell {
-                    Cell::Empty =>Tuxel::new(Idx(x, y, r.z()), self.idx_sender.clone()),
+                    Cell::Empty => Tuxel::new(Idx(x, y, r.z()), self.idx_sender.clone()),
                     _ => return Err(InnerError::CellAlreadyOwned.into()),
                 };
                 let db_tuxel = dbuf.push(tuxel);
@@ -577,9 +577,9 @@ mod test {
         }
     }
 
-    fn is_tuxel(cell: &Cell) -> bool {
+    fn is_empty(cell: &Cell) -> bool {
         match cell {
-            Cell::Tuxel(..) => true,
+            Cell::Empty => true,
             _ => false,
         }
     }
@@ -614,7 +614,7 @@ mod test {
         for idx in idxs.iter() {
             let inner = canvas.lock();
             let cell = &inner.grid[idx.1][idx.0].lock().cells[idx.2];
-            assert!(is_tuxel(cell));
+            assert!(is_empty(cell));
         }
 
         canvas.lock().reclaim();
@@ -622,7 +622,7 @@ mod test {
         for idx in idxs.iter() {
             let inner = canvas.lock();
             let cell = &inner.grid[idx.1][idx.0].lock().cells[idx.2];
-            assert!(is_tuxel(cell));
+            assert!(is_empty(cell));
         }
 
         Ok(())

--- a/src/tui/canvas.rs
+++ b/src/tui/canvas.rs
@@ -57,9 +57,12 @@ impl Canvas {
         {
             for (x, cellstack) in row.iter_mut().enumerate().skip(r.x()).take(r.width()) {
                 let canvas_idx = Idx(x, y, r.0 .2);
-                let cell = cellstack.acquire(canvas_idx.clone(), modifiers.clone())?;
+                let cell = cellstack.acquire(canvas_idx.clone())?;
                 let tuxel = match cell {
-                    Cell::Tuxel(t) => t,
+                    Cell::Tuxel(mut t) => {
+                        t.shared_modifiers = Some(modifiers.clone());
+                        t
+                    },
                     _ => return Err(TuiError::CellAlreadyOwned),
                 };
                 let db_tuxel = dbuf.push(tuxel);
@@ -84,10 +87,6 @@ impl Canvas {
 
     pub(crate) fn dimensions(&self) -> (usize, usize) {
         (self.rectangle.1 .0, self.rectangle.1 .1)
-    }
-
-    fn get_stack(&mut self, idx: Idx) -> Result<Stack> {
-        Ok(self.grid[idx.1][idx.0].clone())
     }
 
     pub(crate) fn reclaim(&mut self) {
@@ -213,7 +212,7 @@ impl Stack {
         }
     }
 
-    fn acquire(&mut self, idx: Idx, shared_modifiers: SharedModifiers) -> Result<Cell> {
+    fn acquire(&mut self, idx: Idx) -> Result<Cell> {
         Ok(self.lock().cells[idx.2].take())
     }
 

--- a/src/tui/canvas.rs
+++ b/src/tui/canvas.rs
@@ -33,7 +33,7 @@ impl CanvasInner {
                 let canvas_idx = Idx(x, y, r.0 .2);
                 let cell = cellstack.acquire(canvas_idx.z());
                 let tuxel = match cell {
-                    Cell::Tuxel(mut t) => t,
+                    Cell::Tuxel(t) => t,
                     _ => return Err(TuiError::CellAlreadyOwned),
                 };
                 let db_tuxel = dbuf.push(tuxel);
@@ -389,6 +389,8 @@ pub(crate) enum Modifier {
     SetBackgroundColor(u8, u8, u8),
     SetBGLightness(f32),
     SetFGLightness(f32),
+    AdjustLightnessBG(f32),
+    AdjustLightnessFG(f32),
 }
 
 impl Modifier {
@@ -408,6 +410,12 @@ impl Modifier {
             }
             (fgcolor, Some(bgcolor), Modifier::SetBGLightness(l)) => {
                 (fgcolor, Some(bgcolor.set_lightness(*l)))
+            }
+            (Some(fgcolor), bgcolor, Modifier::AdjustLightnessFG(l)) => {
+                (Some(fgcolor.adjust_lightness(*l)), bgcolor)
+            }
+            (fgcolor, Some(bgcolor), Modifier::AdjustLightnessBG(l)) => {
+                (fgcolor, Some(bgcolor.adjust_lightness(*l)))
             }
             _ => (fgcolor, bgcolor),
         }

--- a/src/tui/canvas.rs
+++ b/src/tui/canvas.rs
@@ -152,6 +152,14 @@ impl CanvasInner {
 
         Ok(())
     }
+
+    fn swap_rectangles(&mut self, rect1: &Rectangle, rect2: &Rectangle) -> Result<()> {
+        //TODO: verify rect1 and rect2 are not identical
+        //TODO: verify rect1 and rect2 can be swapped
+        //TODO: call swap_tuxels on all pairwise tuxels between the two rectangles
+        unimplemented!("CanvasInner.swap_rectangles");
+        Ok(())
+    }
 }
 
 /// A 2d grid of `Cell`s.
@@ -222,6 +230,10 @@ impl Canvas {
 
     pub(crate) fn swap_tuxels(&self, t1: Idx, t2: Idx) -> Result<()> {
         self.lock().swap_tuxels(t1, t2)
+    }
+
+    pub(crate) fn swap_rectangles(&self, r1: &Rectangle, r2: &Rectangle) -> Result<()> {
+        self.lock().swap_rectangles(r1, r2)
     }
 }
 

--- a/src/tui/canvas.rs
+++ b/src/tui/canvas.rs
@@ -431,11 +431,15 @@ impl Stack {
     }
 
     fn layer_occupied(&self, zdx: usize) -> bool {
-        self.lock().cells.iter().nth(zdx).map_or(false, |c| match c {
-            Cell::Empty => false,
-            Cell::DBTuxel(_) => true,
-            Cell::Tuxel(_) => false,
-        })
+        self.lock()
+            .cells
+            .iter()
+            .nth(zdx)
+            .map_or(false, |c| match c {
+                Cell::Empty => false,
+                Cell::DBTuxel(_) => true,
+                Cell::Tuxel(_) => false,
+            })
     }
 
     fn lock(&self) -> MutexGuard<StackInner> {

--- a/src/tui/canvas.rs
+++ b/src/tui/canvas.rs
@@ -7,6 +7,8 @@ use super::error::{InnerError, Result, TuiError};
 use super::geometry::{Bounds2D, Idx, Indices, Rectangle};
 use super::tuxel::Tuxel;
 
+const CANVAS_DEPTH: usize = 8;
+
 struct CanvasInner {
     grid: Vec<Vec<Stack>>,
     rectangle: Rectangle,
@@ -188,6 +190,17 @@ impl CanvasInner {
             self.swap_tuxels(idx1, idx2)?
         }
         Ok(())
+    }
+
+    fn layer_occupied(&self, zdx: usize) -> bool {
+        for row in self.grid.iter() {
+            for stack in row.iter() {
+                if stack.layer_occupied(zdx) {
+                    return true
+                }
+            }
+        }
+        false
     }
 }
 

--- a/src/tui/canvas.rs
+++ b/src/tui/canvas.rs
@@ -306,6 +306,7 @@ impl Canvas {
         self.lock().swap_rectangles(r1, r2)
     }
 
+    #[cfg(test)]
     pub(crate) fn layer_occupied(&self, zdx: usize) -> bool {
         self.lock().layer_occupied(zdx)
     }

--- a/src/tui/canvas.rs
+++ b/src/tui/canvas.rs
@@ -380,7 +380,7 @@ impl std::fmt::Display for Cell {
 /// abstraction at the same time.
 #[derive(Default)]
 struct StackInner {
-    cells: [Cell; 8],
+    cells: [Cell; CANVAS_DEPTH],
     idx: Idx,
 }
 

--- a/src/tui/canvas.rs
+++ b/src/tui/canvas.rs
@@ -4,7 +4,7 @@ use std::sync::{Arc, Mutex, MutexGuard};
 use super::colors::Rgb;
 use super::drawbuffer::{DBTuxel, DrawBuffer};
 use super::error::{InnerError, Result, TuiError};
-use super::geometry::{Bounds2D, Geometry, Idx, Indices, Rectangle};
+use super::geometry::{Bounds2D, Geometry, Idx, Rectangle};
 use super::tuxel::Tuxel;
 
 const CANVAS_DEPTH: usize = 8;
@@ -178,8 +178,8 @@ impl CanvasInner {
             return Err(InnerError::RectangleDimensionsMustMatch.into());
         }
 
-        let rect1_indices: Indices = rect1.clone().into();
-        let rect2_indices: Indices = rect2.clone().into();
+        let rect1_indices = rect1.clone().into_iter();
+        let rect2_indices = rect2.clone().into_iter();
         log::trace!("swapping {0} and {1}", rect1, rect2);
         for (idx1, idx2) in rect1_indices.zip(rect2_indices) {
             self.swap_tuxels(idx1, idx2)?;

--- a/src/tui/canvas.rs
+++ b/src/tui/canvas.rs
@@ -4,7 +4,7 @@ use std::sync::{Arc, Mutex, MutexGuard};
 use super::colors::Rgb;
 use super::drawbuffer::{DBTuxel, DrawBuffer};
 use super::error::{Result, TuiError};
-use super::geometry::{Bounds2D, Idx, Rectangle};
+use super::geometry::{Bounds2D, Indices, Idx, Rectangle};
 use super::tuxel::Tuxel;
 
 struct CanvasInner {
@@ -154,10 +154,16 @@ impl CanvasInner {
     }
 
     fn swap_rectangles(&mut self, rect1: &Rectangle, rect2: &Rectangle) -> Result<()> {
-        //TODO: verify rect1 and rect2 are not identical
+        if rect1 == rect2 {
+            // donzo!
+            return Ok(())
+        }
         //TODO: verify rect1 and rect2 can be swapped
-        //TODO: call swap_tuxels on all pairwise tuxels between the two rectangles
-        unimplemented!("CanvasInner.swap_rectangles");
+        let rect1_indices: Indices = rect1.clone().into();
+        let rect2_indices: Indices = rect2.clone().into();
+        for (idx1, idx2) in rect1_indices.zip(rect2_indices) {
+            self.swap_tuxels(idx1, idx2)?
+        }
         Ok(())
     }
 }

--- a/src/tui/canvas.rs
+++ b/src/tui/canvas.rs
@@ -4,7 +4,7 @@ use std::sync::{Arc, Mutex, MutexGuard};
 use super::colors::Rgb;
 use super::drawbuffer::{DBTuxel, DrawBuffer};
 use super::error::{InnerError, Result, TuiError};
-use super::geometry::{Bounds2D, Idx, Indices, Rectangle};
+use super::geometry::{Bounds2D, Geometry, Idx, Indices, Rectangle};
 use super::tuxel::Tuxel;
 
 const CANVAS_DEPTH: usize = 8;
@@ -23,6 +23,7 @@ struct CanvasInner {
 impl CanvasInner {
     fn get_draw_buffer(&mut self, c: Canvas, r: Rectangle) -> Result<DrawBuffer> {
         self.reclaim();
+        self.rectangle.contains_or_err(Geometry::Rectangle(&r))?;
         let mut dbuf = DrawBuffer::new(self.tuxel_sender.clone(), r.clone(), c);
         for (y, row) in self
             .grid
@@ -117,8 +118,8 @@ impl CanvasInner {
 
     fn swap_tuxels(&mut self, idx1: Idx, idx2: Idx) -> Result<()> {
         log::trace!("swapping {0} and {1}", idx1, idx2);
-        self.rectangle.contains_or_err(&idx1)?;
-        self.rectangle.contains_or_err(&idx2)?;
+        self.rectangle.contains_or_err(Geometry::Idx(&idx1))?;
+        self.rectangle.contains_or_err(Geometry::Idx(&idx2))?;
         let mut c1 = self.acquire_cell(&idx1)?;
         let mut c2 = match self.acquire_cell(&idx2) {
             Err(e) => {

--- a/src/tui/canvas.rs
+++ b/src/tui/canvas.rs
@@ -129,7 +129,7 @@ impl CanvasInner {
         match &mut c1 {
             Cell::Empty => (),
             Cell::DBTuxel(ref mut dbt) => {
-                dbt.set_canvas_idx(&idx2);
+                dbt.set_canvas_idx(&idx2)?;
             }
             Cell::Tuxel(ref mut t) => {
                 t.set_idx(&idx2);
@@ -138,7 +138,7 @@ impl CanvasInner {
         match &mut c2 {
             Cell::Empty => (),
             Cell::DBTuxel(ref mut dbt) => {
-                dbt.set_canvas_idx(&idx1);
+                dbt.set_canvas_idx(&idx1)?;
             }
             Cell::Tuxel(ref mut t) => {
                 t.set_idx(&idx1);

--- a/src/tui/canvas.rs
+++ b/src/tui/canvas.rs
@@ -47,13 +47,12 @@ impl Canvas {
     pub(crate) fn get_draw_buffer(&mut self, r: Rectangle) -> Result<DrawBuffer> {
         let modifiers = SharedModifiers::default();
         let mut dbuf = DrawBuffer::new(self.tuxel_sender.clone(), r.clone(), modifiers.clone());
-        for (buf_y, (y, row)) in self
+        for (y, row) in self
             .grid
             .iter_mut()
             .enumerate()
             .skip(r.y())
             .take(r.height())
-            .enumerate()
         {
             for (x, cellstack) in row.iter_mut().enumerate().skip(r.x()).take(r.width()) {
                 let canvas_idx = Idx(x, y, r.0 .2);
@@ -174,7 +173,7 @@ impl std::fmt::Display for Cell {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self.get_content() {
             Ok(v) => write!(f, "{}", v),
-            Err(e) => Ok(()),
+            Err(_) => Ok(()),
         }
     }
 }

--- a/src/tui/canvas.rs
+++ b/src/tui/canvas.rs
@@ -87,6 +87,9 @@ impl CanvasInner {
                 Ok(tuxel) => {
                     let idx = tuxel.idx();
                     let _ = self.grid[idx.y()][idx.x()].replace(idx.z(), Cell::Empty);
+                    self.idx_sender
+                        .send(idx)
+                        .expect("idx sender should have plenty of room for more idxes");
                 }
                 Err(std::sync::mpsc::TryRecvError::Disconnected) => {
                     unreachable!();

--- a/src/tui/canvas.rs
+++ b/src/tui/canvas.rs
@@ -245,7 +245,7 @@ impl Canvas {
         }
         let (idx_sender, idx_receiver) = sync_channel(10000);
         let (tuxel_sender, tuxel_receiver) = channel();
-        let mut s = Self {
+        let c = Self {
             inner: Arc::new(Mutex::new(CanvasInner {
                 grid,
                 rectangle,
@@ -255,9 +255,8 @@ impl Canvas {
                 tuxel_receiver,
             })),
         };
-        s.draw_all().expect("enqueuing entire canvas rerender");
 
-        s
+        c
     }
 
     fn lock(&self) -> MutexGuard<CanvasInner> {

--- a/src/tui/canvas.rs
+++ b/src/tui/canvas.rs
@@ -175,10 +175,11 @@ impl CanvasInner {
 
     fn swap_rectangles(&mut self, rect1: &Rectangle, rect2: &Rectangle) -> Result<()> {
         if rect1 == rect2 {
-            // donzo!
             return Ok(());
+        } else if rect1.width() != rect2.width() || rect1.height() != rect2.height() {
+            return Err(InnerError::RectangleDimensionsMustMatch.into());
         }
-        //TODO: verify rect1 and rect2 can be swapped
+
         let rect1_indices: Indices = rect1.clone().into();
         let rect2_indices: Indices = rect2.clone().into();
         for (idx1, idx2) in rect1_indices.zip(rect2_indices) {

--- a/src/tui/canvas.rs
+++ b/src/tui/canvas.rs
@@ -451,8 +451,8 @@ impl Stack {
     fn display_cell_type(&self, zdx: usize) -> &str {
         match &self.lock().cells[zdx] {
             Cell::Empty => "E",
-            Cell::Tuxel(t) => "T",
-            Cell::DBTuxel(t) => "D",
+            Cell::Tuxel(_) => "T",
+            Cell::DBTuxel(_) => "D",
         }
     }
 }
@@ -467,8 +467,6 @@ impl Stack {
     }
 
     pub(crate) fn colors(&self) -> (Option<Rgb>, Option<Rgb>) {
-        let fg = Rgb::default();
-        let bg = Rgb::default();
         if let Some(idx) = self.top() {
             self.lock()
                 .cells
@@ -500,8 +498,6 @@ pub(crate) enum Modifier {
     SetBackgroundColor(u8, u8, u8),
     SetBGLightness(f32),
     SetFGLightness(f32),
-    AdjustLightnessBG(f32),
-    AdjustLightnessFG(f32),
 }
 
 impl Modifier {
@@ -521,12 +517,6 @@ impl Modifier {
             }
             (fgcolor, Some(bgcolor), Modifier::SetBGLightness(l)) => {
                 (fgcolor, Some(bgcolor.set_lightness(*l)))
-            }
-            (Some(fgcolor), bgcolor, Modifier::AdjustLightnessFG(l)) => {
-                (Some(fgcolor.adjust_lightness(*l)), bgcolor)
-            }
-            (fgcolor, Some(bgcolor), Modifier::AdjustLightnessBG(l)) => {
-                (fgcolor, Some(bgcolor.adjust_lightness(*l)))
             }
             _ => (fgcolor, bgcolor),
         }
@@ -554,7 +544,7 @@ mod test {
     #[case::base((5, 5))]
     #[case::realistic((274, 75))]
     fn get_layer_validate_draw_buffer_size(#[case] dims: (usize, usize)) -> Result<()> {
-        let mut canvas = Canvas::new(dims.0, dims.1);
+        let canvas = Canvas::new(dims.0, dims.1);
         let dbuf = canvas.get_layer(0)?;
         let inner = dbuf.lock();
         assert_eq!(inner.buf.len(), dims.1);
@@ -576,7 +566,7 @@ mod test {
         #[case] canvas_dims: (usize, usize),
         #[case] rect: Rectangle,
     ) -> Result<()> {
-        let mut canvas = Canvas::new(canvas_dims.0, canvas_dims.1);
+        let canvas = Canvas::new(canvas_dims.0, canvas_dims.1);
         let buffer = canvas.get_draw_buffer(rect.clone())?;
 
         let inner = buffer.lock();
@@ -614,7 +604,7 @@ mod test {
         #[case] canvas_dims: (usize, usize),
         #[case] rect: Rectangle,
     ) -> Result<()> {
-        let mut canvas = Canvas::new(canvas_dims.0, canvas_dims.1);
+        let canvas = Canvas::new(canvas_dims.0, canvas_dims.1);
         let dbuf = canvas.get_draw_buffer(rect.clone())?;
 
         let mut idxs: Vec<Idx> = Vec::new();

--- a/src/tui/canvas.rs
+++ b/src/tui/canvas.rs
@@ -114,6 +114,7 @@ impl CanvasInner {
     }
 
     fn swap_tuxels(&mut self, idx1: Idx, idx2: Idx) -> Result<()> {
+        log::trace!("swapping {0} and {1}", idx1, idx2);
         self.rectangle.contains_or_err(&idx1)?;
         self.rectangle.contains_or_err(&idx2)?;
         let mut c1 = self.acquire_cell(&idx1)?;
@@ -182,6 +183,7 @@ impl CanvasInner {
 
         let rect1_indices: Indices = rect1.clone().into();
         let rect2_indices: Indices = rect2.clone().into();
+        log::trace!("swapping {0} and {1}", rect1, rect2);
         for (idx1, idx2) in rect1_indices.zip(rect2_indices) {
             self.swap_tuxels(idx1, idx2)?
         }

--- a/src/tui/canvas.rs
+++ b/src/tui/canvas.rs
@@ -45,6 +45,7 @@ impl Canvas {
     }
 
     pub(crate) fn get_draw_buffer(&mut self, r: Rectangle) -> Result<DrawBuffer> {
+        self.reclaim();
         let modifiers = SharedModifiers::default();
         let mut dbuf = DrawBuffer::new(self.tuxel_sender.clone(), r.clone(), modifiers.clone());
         for (y, row) in self
@@ -88,7 +89,7 @@ impl Canvas {
         (self.rectangle.1 .0, self.rectangle.1 .1)
     }
 
-    pub(crate) fn reclaim(&mut self) {
+    fn reclaim(&mut self) {
         loop {
             match self.tuxel_receiver.try_recv() {
                 Ok(tuxel) => {

--- a/src/tui/canvas.rs
+++ b/src/tui/canvas.rs
@@ -188,8 +188,9 @@ impl CanvasInner {
         let rect2_indices: Indices = rect2.clone().into();
         log::trace!("swapping {0} and {1}", rect1, rect2);
         for (idx1, idx2) in rect1_indices.zip(rect2_indices) {
-            self.swap_tuxels(idx1, idx2)?
+            self.swap_tuxels(idx1, idx2)?;
         }
+        self.reclaim();
         Ok(())
     }
 
@@ -307,6 +308,11 @@ impl Canvas {
 
     pub(crate) fn layer_occupied(&self, zdx: usize) -> bool {
         self.lock().layer_occupied(zdx)
+    }
+
+    pub(crate) fn reclaim(&mut self) -> Result<()> {
+        self.lock().reclaim();
+        Ok(())
     }
 }
 

--- a/src/tui/canvas.rs
+++ b/src/tui/canvas.rs
@@ -335,13 +335,6 @@ impl Cell {
         }
     }
 
-    pub(crate) fn coordinates(&self) -> (usize, usize) {
-        match self {
-            Cell::DBTuxel(d) => d.coordinates(),
-            Cell::Empty => (0, 0),
-        }
-    }
-
     pub(crate) fn colors(&self) -> (Option<Rgb>, Option<Rgb>) {
         match self {
             Cell::DBTuxel(d) => d.colors(),
@@ -449,11 +442,8 @@ impl Stack {
 
 impl Stack {
     pub(crate) fn coordinates(&self) -> (usize, usize) {
-        if let Some(idx) = self.top() {
-            self.lock().cells[idx].coordinates()
-        } else {
-            (0, 0)
-        }
+        let idx = self.lock().idx.clone();
+        (idx.x(), idx.y())
     }
 
     pub(crate) fn colors(&self) -> (Option<Rgb>, Option<Rgb>) {

--- a/src/tui/canvas.rs
+++ b/src/tui/canvas.rs
@@ -632,7 +632,7 @@ mod test {
         for idx in idxs.iter() {
             let inner = canvas.lock();
             let cell = &inner.grid[idx.1][idx.0].lock().cells[idx.2];
-            assert!(is_dbtuxel(cell));
+            assert!(is_tuxel(cell));
         }
 
         canvas.lock().reclaim();

--- a/src/tui/canvas.rs
+++ b/src/tui/canvas.rs
@@ -381,7 +381,7 @@ impl std::fmt::Display for Stack {
     }
 }
 
-#[derive(Clone)]
+#[derive(Clone, PartialEq, Eq, Hash)]
 pub(crate) enum Modifier {
     ForegroundColor(u8, u8, u8),
     BackgroundColor(u8, u8, u8),

--- a/src/tui/colors.rs
+++ b/src/tui/colors.rs
@@ -1,6 +1,6 @@
 use palette::rgb::Rgb as PaletteRgb;
 use palette::stimulus::FromStimulus;
-use palette::{Lighten, LightenAssign};
+use palette::LightenAssign;
 
 #[derive(Clone, Default)]
 pub(crate) struct Rgb {
@@ -45,21 +45,6 @@ impl Rgb {
 
         let mut new_color = self.clone();
         new_color.color.lighten_assign(lightness);
-        new_color
-    }
-
-    #[inline(always)]
-    pub(crate) fn adjust_lightness(&self, adjustment: f32) -> Rgb {
-        let adjustment = if adjustment > 1.0 {
-            1.0
-        } else if adjustment < -1.0 {
-            -1.0
-        } else {
-            adjustment
-        };
-
-        let mut new_color = self.clone();
-        new_color.color = new_color.color.lighten(adjustment);
         new_color
     }
 }

--- a/src/tui/colors.rs
+++ b/src/tui/colors.rs
@@ -1,0 +1,57 @@
+use palette::rgb::Rgb as PaletteRgb;
+use palette::stimulus::FromStimulus;
+use palette::LightenAssign;
+
+#[derive(Clone, Default)]
+pub(crate) struct Rgb {
+    color: PaletteRgb,
+}
+
+impl Rgb {
+    pub(crate) fn new(r: u8, g: u8, b: u8) -> Self {
+        Self {
+            color: PaletteRgb::new(
+                f32::from_stimulus(r),
+                f32::from_stimulus(g),
+                f32::from_stimulus(b),
+            ),
+        }
+    }
+
+    #[inline(always)]
+    pub(crate) fn r(&self) -> u8 {
+        u8::from_stimulus(self.color.red)
+    }
+
+    #[inline(always)]
+    pub(crate) fn g(&self) -> u8 {
+        u8::from_stimulus(self.color.green)
+    }
+
+    #[inline(always)]
+    pub(crate) fn b(&self) -> u8 {
+        u8::from_stimulus(self.color.blue)
+    }
+
+    pub(crate) fn set_lightness(&self, lightness: f32) -> Rgb {
+        let lightness = if lightness > 1.0 {
+            1.0
+        } else {
+            lightness
+        };
+
+        let mut new_color = self.clone();
+        new_color.color.lighten_assign(lightness);
+        new_color
+    }
+}
+
+impl From<Rgb> for crossterm::style::Color {
+    fn from(f: Rgb) -> crossterm::style::Color {
+        crossterm::style::Color::Rgb {
+            r: f.r(),
+            g: f.g(),
+            b: f.b(),
+        }
+    }
+}

--- a/src/tui/colors.rs
+++ b/src/tui/colors.rs
@@ -1,6 +1,6 @@
 use palette::rgb::Rgb as PaletteRgb;
 use palette::stimulus::FromStimulus;
-use palette::LightenAssign;
+use palette::{Lighten, LightenAssign};
 
 #[derive(Clone, Default)]
 pub(crate) struct Rgb {
@@ -33,15 +33,33 @@ impl Rgb {
         u8::from_stimulus(self.color.blue)
     }
 
+    #[inline(always)]
     pub(crate) fn set_lightness(&self, lightness: f32) -> Rgb {
         let lightness = if lightness > 1.0 {
             1.0
+        } else if lightness < 0.0 {
+            0.0
         } else {
             lightness
         };
 
         let mut new_color = self.clone();
         new_color.color.lighten_assign(lightness);
+        new_color
+    }
+
+    #[inline(always)]
+    pub(crate) fn adjust_lightness(&self, adjustment: f32) -> Rgb {
+        let adjustment = if adjustment > 1.0 {
+            1.0
+        } else if adjustment < -1.0 {
+            -1.0
+        } else {
+            adjustment
+        };
+
+        let mut new_color = self.clone();
+        new_color.color = new_color.color.lighten(adjustment);
         new_color
     }
 }

--- a/src/tui/crossterm.rs
+++ b/src/tui/crossterm.rs
@@ -11,7 +11,8 @@ use crossterm::{
 
 use super::canvas::{Canvas, Modifier};
 use super::error::Result;
-use super::events::{Direction, Event, EventSource, UserInput};
+use super::events::{Event, EventSource, UserInput};
+use super::geometry::Direction;
 use super::renderer::Renderer;
 
 pub(crate) struct Crossterm<T: Write> {

--- a/src/tui/crossterm.rs
+++ b/src/tui/crossterm.rs
@@ -32,11 +32,7 @@ impl<T: Write> Crossterm<T> {
 
 impl<T: Write> Drop for Crossterm<T> {
     fn drop(&mut self) {
-        self.w.execute(cursor::Show).expect("showing cursor again");
-        self.w
-            .execute(terminal::LeaveAlternateScreen)
-            .expect("leaving alternate screen");
-        terminal::disable_raw_mode().expect("disabling raw mode");
+        self.recover();
     }
 }
 
@@ -114,6 +110,14 @@ impl<T: Write> Renderer for Crossterm<T> {
 
     fn size_hint(&self) -> Result<(u16, u16)> {
         size()
+    }
+
+    fn recover(&mut self) {
+        self.w.execute(cursor::Show).expect("showing cursor again");
+        self.w
+            .execute(terminal::LeaveAlternateScreen)
+            .expect("leaving alternate screen");
+        terminal::disable_raw_mode().expect("disabling raw mode");
     }
 }
 

--- a/src/tui/crossterm.rs
+++ b/src/tui/crossterm.rs
@@ -75,7 +75,7 @@ impl<T: Write> Renderer for Crossterm<T> {
         self.w
             .queue(cursor::SavePosition)
             .with_context(|| "queue save cursor position")?;
-        for stack in c {
+        for stack in c.get_changed() {
             for command in stack.modifiers()?.iter() {
                 self.queue(command)
                     .with_context(|| "queue tuxel modifier")?;

--- a/src/tui/crossterm.rs
+++ b/src/tui/crossterm.rs
@@ -5,11 +5,10 @@ use crossterm::{
     cursor,
     event::{self, Event as CrossTermEvent, KeyCode, KeyEvent},
     style,
-    style::Color,
     terminal, ExecutableCommand, QueueableCommand,
 };
 
-use super::canvas::{Canvas, Modifier};
+use super::canvas::Canvas;
 use super::error::Result;
 use super::events::{Event, EventSource, UserInput};
 use super::geometry::Direction;

--- a/src/tui/crossterm.rs
+++ b/src/tui/crossterm.rs
@@ -40,7 +40,7 @@ impl<T: Write> Renderer for Crossterm<T> {
     fn clear(&mut self, c: &Canvas) -> Result<()> {
         let (width, height) = c.dimensions();
         self.w
-            .queue(terminal::BeginSynchronizedUpdate)
+            .execute(terminal::BeginSynchronizedUpdate)
             .with_context(|| "queue synchronized update")?;
         self.w
             .queue(cursor::SavePosition)
@@ -59,7 +59,7 @@ impl<T: Write> Renderer for Crossterm<T> {
             .queue(cursor::RestorePosition)
             .with_context(|| "queue restore position")?;
         self.w
-            .queue(terminal::EndSynchronizedUpdate)
+            .execute(terminal::EndSynchronizedUpdate)
             .with_context(|| "queue end synchronized update")?;
         self.w.flush().with_context(|| "flush writer")?;
         Ok(())
@@ -67,11 +67,11 @@ impl<T: Write> Renderer for Crossterm<T> {
 
     fn render(&mut self, c: &Canvas) -> Result<()> {
         self.w
-            .queue(terminal::BeginSynchronizedUpdate)
-            .with_context(|| "queue synchronized update")?;
+            .execute(terminal::BeginSynchronizedUpdate)
+            .with_context(|| "execute synchronized update")?;
         self.w
-            .queue(cursor::SavePosition)
-            .with_context(|| "queue save cursor position")?;
+            .execute(cursor::SavePosition)
+            .with_context(|| "execute save cursor position")?;
         for stack in c.get_changed() {
             let (fgcolor, bgcolor) = stack.colors();
             let output = match stack.content() {
@@ -80,31 +80,30 @@ impl<T: Write> Renderer for Crossterm<T> {
             };
             let (x, y) = stack.coordinates();
             self.w
-                .queue(cursor::MoveTo(x as u16, y as u16))
-                .with_context(|| "queue moving cursor")?;
+                .execute(cursor::MoveTo(x as u16, y as u16))
+                .with_context(|| "execute moving cursor")?;
             if let Some(bg) = bgcolor {
-                self.w.queue(style::SetBackgroundColor(bg.into()))?;
+                self.w.execute(style::SetBackgroundColor(bg.into()))?;
             }
             if let Some(fg) = fgcolor {
-                self.w.queue(style::SetForegroundColor(fg.into()))?;
+                self.w.execute(style::SetForegroundColor(fg.into()))?;
             }
             self.w
-                .queue(style::Print(output))
-                .with_context(|| "queue printing cell text")?;
+                .execute(style::Print(output))
+                .with_context(|| "execute printing cell text")?;
             self.w
-                .queue(style::ResetColor)
-                .with_context(|| "queue color reset")?;
+                .execute(style::ResetColor)
+                .with_context(|| "execute color reset")?;
             self.w
-                .queue(style::SetAttribute(style::Attribute::Reset))
-                .with_context(|| "queue attribute reset")?;
+                .execute(style::SetAttribute(style::Attribute::Reset))
+                .with_context(|| "execute attribute reset")?;
         }
         self.w
-            .queue(cursor::RestorePosition)
-            .with_context(|| "queue restore position")?;
+            .execute(cursor::RestorePosition)
+            .with_context(|| "execute restore position")?;
         self.w
-            .queue(terminal::EndSynchronizedUpdate)
-            .with_context(|| "queue end synchronized update")?;
-        self.w.flush().with_context(|| "flush writer")?;
+            .execute(terminal::EndSynchronizedUpdate)
+            .with_context(|| "execute end synchronized update")?;
         Ok(())
     }
 

--- a/src/tui/drawbuffer.rs
+++ b/src/tui/drawbuffer.rs
@@ -192,10 +192,10 @@ impl DrawBufferInner {
             return Ok(())
         }
 
-        let mut new_rect = self.rectangle.clone();
-        new_rect.0.2 = zdx;
+        let old = self.rectangle.clone();
+        self.rectangle.0.2 = zdx;
 
-        self.canvas.swap_rectangles(&self.rectangle, &new_rect)?;
+        self.canvas.swap_rectangles(&self.rectangle, &old)?;
         Ok(())
     }
 

--- a/src/tui/drawbuffer.rs
+++ b/src/tui/drawbuffer.rs
@@ -18,7 +18,11 @@ pub(crate) struct DrawBufferInner {
 impl std::fmt::Display for DrawBufferInner {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         for row in self.buf.iter() {
-            write!(f, "{}\n", row.iter().map(|t| t.content()).collect::<String>())?
+            write!(
+                f,
+                "{}\n",
+                row.iter().map(|t| t.content()).collect::<String>()
+            )?
         }
         Ok(())
     }

--- a/src/tui/drawbuffer.rs
+++ b/src/tui/drawbuffer.rs
@@ -2,7 +2,7 @@ use std::sync::mpsc::Sender;
 use std::sync::{Arc, Mutex, MutexGuard};
 
 use super::canvas::{Canvas, Modifier, SharedModifiers};
-use super::error::{TuiError, Result};
+use super::error::{Result, TuiError};
 use super::geometry::{Direction, Idx, Position, Rectangle};
 use super::tuxel::Tuxel;
 
@@ -73,6 +73,10 @@ impl DrawBufferInner {
             .map(|row| row.get_mut(x))
             .flatten()
             .expect("using the buffer's rectangle should always yield a tuxel")
+    }
+
+    fn rectangle(&self) -> Rectangle {
+        self.rectangle.clone()
     }
 
     fn fill(&mut self, c: char) -> Result<()> {
@@ -207,6 +211,7 @@ impl DrawBufferInner {
                 }
             }
         }
+        self.rectangle.translate(magnitude, dir)?;
         Ok(())
     }
 }
@@ -289,6 +294,10 @@ impl DrawBuffer {
 
     pub(crate) fn write_center(&mut self, s: &str) -> Result<()> {
         self.lock().write_center(s)
+    }
+
+    pub(crate) fn rectangle(&self) -> Rectangle {
+        self.lock().rectangle()
     }
 }
 

--- a/src/tui/drawbuffer.rs
+++ b/src/tui/drawbuffer.rs
@@ -440,10 +440,6 @@ impl DBTuxel {
         self.lock().tuxel_is_active(self.buf_idx.0, self.buf_idx.1)
     }
 
-    pub(crate) fn coordinates(&self) -> (usize, usize) {
-        (self.canvas_idx.0, self.canvas_idx.1)
-    }
-
     pub(crate) fn set_canvas_idx(&mut self, new_idx: &Idx) -> Result<()> {
         self.canvas_idx = new_idx.clone();
         // NOTE: in the early stages of development the only case i can think of where this would

--- a/src/tui/drawbuffer.rs
+++ b/src/tui/drawbuffer.rs
@@ -210,6 +210,17 @@ impl DrawBuffer {
         }
     }
 
+    pub(crate) fn push(&mut self, t: Tuxel) -> DBTuxel {
+        let mut inner = self.lock();
+        let idx = t.idx();
+        let buf_idx = Idx(idx.0 - inner.rectangle.x(), idx.1 - inner.rectangle.y(), 0);
+        inner.buf.iter_mut().nth(buf_idx.1).expect("meow").push(t);
+        DBTuxel {
+            parent: self.inner.clone(),
+            idx,
+            buf_idx,
+        }
+    }
 
     pub(crate) fn modify(&mut self, modifier: Modifier) {
         self.lock().modifiers.push(modifier)
@@ -242,18 +253,6 @@ impl<'a> DrawBuffer {
             .as_ref()
             .lock()
             .expect("TODO: handle thread panicking better than this")
-    }
-
-    pub(crate) fn push(&mut self, t: Tuxel) -> DBTuxel {
-        let mut inner = self.lock();
-        let idx = t.idx();
-        let buf_idx = Idx(idx.0 - inner.rectangle.x(), idx.1 - inner.rectangle.y(), 0);
-        inner.buf.iter_mut().nth(buf_idx.1).expect("meow").push(t);
-        DBTuxel {
-            parent: self.inner.clone(),
-            idx,
-            buf_idx,
-        }
     }
 }
 

--- a/src/tui/drawbuffer.rs
+++ b/src/tui/drawbuffer.rs
@@ -1,9 +1,9 @@
-use std::sync::mpsc::{channel, Sender};
+use std::sync::mpsc::Sender;
 use std::sync::{Arc, Mutex, MutexGuard};
 
 use super::canvas::{Modifier, SharedModifiers};
 use super::error::Result;
-use super::geometry::{Bounds2D, Idx, Position, Rectangle};
+use super::geometry::{Idx, Position, Rectangle};
 use super::tuxel::Tuxel;
 
 #[derive(Default)]
@@ -208,10 +208,6 @@ impl DrawBuffer {
         }
     }
 
-    pub(crate) fn set_buf(&mut self, buf: Vec<Vec<Tuxel>>) -> Result<()> {
-        self.lock().buf = buf;
-        Ok(())
-    }
 
     pub(crate) fn modify(&mut self, modifier: Modifier) {
         self.lock().modifiers.push(modifier)
@@ -235,18 +231,6 @@ impl DrawBuffer {
 
     pub(crate) fn write_center(&mut self, s: &str) -> Result<()> {
         self.lock().write_center(s)
-    }
-
-    fn tuxel_content(&self, x: usize, y: usize) -> Result<char> {
-        self.lock().tuxel_content(x, y)
-    }
-
-    fn tuxel_is_active(&self, x: usize, y: usize) -> Result<bool> {
-        self.lock().tuxel_is_active(x, y)
-    }
-
-    fn tuxel_modifiers(&self, x: usize, y: usize) -> Result<Vec<Modifier>> {
-        self.lock().tuxel_modifiers(x, y)
     }
 }
 

--- a/src/tui/drawbuffer.rs
+++ b/src/tui/drawbuffer.rs
@@ -275,6 +275,7 @@ impl DrawBufferInner {
                 }
             }
         }
+        self.canvas.reclaim()?;
         Ok(())
     }
 }
@@ -406,6 +407,7 @@ impl Drop for DrawBuffer {
                 let _ = self.sender.send(tuxel);
             }
         }
+        let _ = inner.canvas.reclaim();
     }
 }
 

--- a/src/tui/drawbuffer.rs
+++ b/src/tui/drawbuffer.rs
@@ -207,7 +207,6 @@ impl DrawBufferInner {
 
     fn switch_layer(&mut self, zdx: usize) -> Result<()> {
         if self.rectangle.0 .2 == zdx {
-            // shh, don't tell the caller that we didn't have to do anything
             return Ok(());
         }
         log::trace!("switching layer from {0} to {1}", self.rectangle.z(), zdx);

--- a/src/tui/drawbuffer.rs
+++ b/src/tui/drawbuffer.rs
@@ -186,6 +186,19 @@ impl DrawBufferInner {
         Ok(())
     }
 
+    fn switch_layer(&mut self, zdx: usize) -> Result<()> {
+        if self.rectangle.0.2 == zdx {
+            // shh, don't tell the caller that we didn't have to do anything
+            return Ok(())
+        }
+
+        let mut new_rect = self.rectangle.clone();
+        new_rect.0.2 = zdx;
+
+        self.canvas.swap_rectangles(&self.rectangle, &new_rect)?;
+        Ok(())
+    }
+
     fn translate(&mut self, dir: Direction) -> Result<()> {
         self.rectangle.translate(1, &dir)?;
         let canvas_bounds = self.canvas.bounds();
@@ -319,6 +332,10 @@ impl DrawBuffer {
 
     pub(crate) fn translate(&self, dir: Direction) -> Result<()> {
         self.lock().translate(dir)
+    }
+
+    pub(crate) fn switch_layer(&self, zdx: usize) -> Result<()> {
+        self.lock().switch_layer(zdx)
     }
 
     pub(crate) fn rectangle(&self) -> Rectangle {

--- a/src/tui/drawbuffer.rs
+++ b/src/tui/drawbuffer.rs
@@ -3,7 +3,7 @@ use std::sync::{Arc, Mutex, MutexGuard};
 
 use super::canvas::{Canvas, Modifier};
 use super::colors::Rgb;
-use super::error::{Result, InnerError, TuiError};
+use super::error::{InnerError, Result, TuiError};
 use super::geometry::{Direction, Idx, Position, Rectangle};
 use super::tuxel::Tuxel;
 
@@ -13,6 +13,12 @@ pub(crate) struct DrawBufferInner {
     pub(crate) buf: Vec<Vec<Tuxel>>,
     pub(crate) modifiers: Vec<Modifier>,
     pub(crate) canvas: Canvas,
+}
+
+impl std::fmt::Display for DrawBufferInner {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{0}", self.rectangle)
+    }
 }
 
 impl DrawBufferInner {
@@ -83,7 +89,8 @@ impl DrawBufferInner {
     #[inline(always)]
     fn get_tuxel(&self, pos: Position) -> Result<&Tuxel> {
         let (x, y) = self.rectangle.relative_idx(&pos);
-        let t = self.buf
+        let t = self
+            .buf
             .get(y)
             .ok_or(InnerError::OutOfBoundsY(y))?
             .get(x)

--- a/src/tui/drawbuffer.rs
+++ b/src/tui/drawbuffer.rs
@@ -1,17 +1,17 @@
 use std::sync::mpsc::Sender;
 use std::sync::{Arc, Mutex, MutexGuard};
 
-use super::canvas::{Modifier, SharedModifiers};
+use super::canvas::{Canvas, Modifier, SharedModifiers};
 use super::error::Result;
 use super::geometry::{Idx, Position, Rectangle};
 use super::tuxel::Tuxel;
 
-#[derive(Default)]
 pub(crate) struct DrawBufferInner {
     pub(crate) rectangle: Rectangle,
     pub(crate) border: bool,
     pub(crate) buf: Vec<Vec<Tuxel>>,
     pub(crate) modifiers: SharedModifiers,
+    pub(crate) canvas: Canvas,
 }
 
 impl DrawBufferInner {
@@ -191,6 +191,7 @@ impl DrawBuffer {
         sender: Sender<Tuxel>,
         rectangle: Rectangle,
         modifiers: SharedModifiers,
+        canvas: Canvas,
     ) -> Self {
         let mut buf: Vec<_> = Vec::with_capacity(rectangle.height());
         for _ in 0..rectangle.height() {
@@ -203,6 +204,7 @@ impl DrawBuffer {
                 border: false,
                 buf,
                 modifiers,
+                canvas,
             })),
             sender,
         }

--- a/src/tui/drawbuffer.rs
+++ b/src/tui/drawbuffer.rs
@@ -224,6 +224,7 @@ impl DrawBufferInner {
     fn translate(&mut self, dir: Direction) -> Result<()> {
         self.rectangle.translate(1, &dir)?;
         let canvas_bounds = self.canvas.bounds();
+        log::trace!("translating DrawBuffer {}", dir);
         match dir {
             Direction::Left => {
                 for t in self.buf.iter_mut().flatten() {
@@ -231,7 +232,11 @@ impl DrawBufferInner {
                     let mut new_idx = current_idx.clone();
                     if new_idx.0 > 0 {
                         new_idx.0 -= 1
-                    } //TODO: figure out how to handle the 0 case
+                    } else {
+                        return Err(
+                            InnerError::DrawBufferTranslationFailed(String::from("")).into()
+                        );
+                    }
                     self.canvas.swap_tuxels(current_idx, new_idx.clone())?;
                     t.set_idx(&new_idx);
                 }
@@ -242,7 +247,11 @@ impl DrawBufferInner {
                     let mut new_idx = current_idx.clone();
                     if new_idx.0 < canvas_bounds.width() {
                         new_idx.0 += 1
-                    };
+                    } else {
+                        return Err(
+                            InnerError::DrawBufferTranslationFailed(String::from("")).into()
+                        );
+                    }
                     self.canvas.swap_tuxels(current_idx, new_idx.clone())?;
                     t.set_idx(&new_idx);
                 }
@@ -253,6 +262,10 @@ impl DrawBufferInner {
                     let mut new_idx = current_idx.clone();
                     if new_idx.1 > 0 {
                         new_idx.1 -= 1
+                    } else {
+                        return Err(
+                            InnerError::DrawBufferTranslationFailed(String::from("")).into()
+                        );
                     }
 
                     self.canvas.swap_tuxels(current_idx, new_idx.clone())?;

--- a/src/tui/drawbuffer.rs
+++ b/src/tui/drawbuffer.rs
@@ -86,7 +86,6 @@ impl DrawBufferInner {
     fn get_tuxel_mut(&mut self, pos: Position) -> Result<&mut Tuxel> {
 
         let (x, y) = self.rectangle.relative_idx(&pos);
-        log::trace!("get_tuxel_mut: {0}, {1}", x, y);
         let t = self
             .buf
             .get_mut(y)

--- a/src/tui/drawbuffer.rs
+++ b/src/tui/drawbuffer.rs
@@ -17,7 +17,10 @@ pub(crate) struct DrawBufferInner {
 
 impl std::fmt::Display for DrawBufferInner {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{0}", self.rectangle)
+        for row in self.buf.iter() {
+            write!(f, "{}\n", row.iter().map(|t| t.content()).collect::<String>())?
+        }
+        Ok(())
     }
 }
 
@@ -294,6 +297,12 @@ impl DrawBufferInner {
 pub(crate) struct DrawBuffer {
     inner: Arc<Mutex<DrawBufferInner>>,
     sender: Sender<Tuxel>,
+}
+
+impl std::fmt::Display for DrawBuffer {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        self.lock().fmt(f)
+    }
 }
 
 impl DrawBuffer {

--- a/src/tui/drawbuffer.rs
+++ b/src/tui/drawbuffer.rs
@@ -187,15 +187,21 @@ impl DrawBufferInner {
     }
 
     fn switch_layer(&mut self, zdx: usize) -> Result<()> {
-        if self.rectangle.0.2 == zdx {
+        if self.rectangle.0 .2 == zdx {
             // shh, don't tell the caller that we didn't have to do anything
-            return Ok(())
+            return Ok(());
         }
 
         let old = self.rectangle.clone();
-        self.rectangle.0.2 = zdx;
+        self.rectangle.0 .2 = zdx;
 
         self.canvas.swap_rectangles(&self.rectangle, &old)?;
+
+        for tuxel in self.buf.iter_mut().map(|v| v.iter_mut()).flatten() {
+            let mut idx = tuxel.idx();
+            idx.2 = zdx;
+            tuxel.set_idx(&idx);
+        }
         Ok(())
     }
 

--- a/src/tui/error.rs
+++ b/src/tui/error.rs
@@ -60,17 +60,11 @@ pub(crate) enum InnerError {
     #[error("cell already owned")]
     CellAlreadyOwned,
 
-    #[error("{0}ward translation impossible")]
-    TranslationImpossible(super::geometry::Direction),
-
     #[error("out of bounds x: {0}")]
     OutOfBoundsX(usize),
 
     #[error("out of bounds y: {0}")]
     OutOfBoundsY(usize),
-
-    #[error("out of bounds z: {0}")]
-    OutOfBoundsZ(usize),
 
     #[error("idx channel send failed")]
     IdxSendError(#[from] std::sync::mpsc::SendError<crate::tui::geometry::Idx>),
@@ -86,9 +80,6 @@ pub(crate) enum InnerError {
         dir: super::geometry::Direction,
         rect: super::geometry::Rectangle,
     },
-
-    #[error("top tuxel in stack not found")]
-    TopTuxelNotFound,
 
     #[error("drawbuffer translation failed: {0}")]
     DrawBufferTranslationFailed(String),

--- a/src/tui/error.rs
+++ b/src/tui/error.rs
@@ -29,6 +29,9 @@ pub(crate) enum TuiError {
     #[error("tuxel channel send failed")]
     TuxelSendError(#[from] std::sync::mpsc::SendError<crate::tui::tuxel::Tuxel>),
 
+    #[error("invalid translation")]
+    InvalidTranslation,
+
     #[error("io error")]
     StdIOError(#[from] std::io::Error),
 

--- a/src/tui/error.rs
+++ b/src/tui/error.rs
@@ -104,4 +104,7 @@ pub(crate) enum InnerError {
 
     #[error("exceeded retry limit for locking drawbuffer: {0:?}")]
     ExceedRetryLimitForLockingDrawBuffer(String),
+
+    #[error("rectangle dimensions must match")]
+    RectangleDimensionsMustMatch,
 }

--- a/src/tui/error.rs
+++ b/src/tui/error.rs
@@ -50,4 +50,7 @@ pub(crate) enum TuiError {
         #[from]
         source: anyhow::Error,
     },
+
+    #[error("exceeded retry limit for locking drawbuffer: {0:?}")]
+    ExceedRetryLimitForLockingDrawBuffer(String),
 }

--- a/src/tui/error.rs
+++ b/src/tui/error.rs
@@ -11,6 +11,18 @@ pub(crate) enum TuiError {
     #[error("cell already owned")]
     CellAlreadyOwned,
 
+    #[error("{0}ward translation impossible")]
+    TranslationImpossible(super::geometry::Direction),
+
+    #[error("out of bounds x - {0}")]
+    OutOfBoundsX(usize),
+
+    #[error("out of bounds y - {0}")]
+    OutOfBoundsY(usize),
+
+    #[error("out of bounds z - {0}")]
+    OutOfBoundsZ(usize),
+
     #[error("idx channel send failed")]
     IdxSendError(#[from] std::sync::mpsc::SendError<crate::tui::geometry::Idx>),
 

--- a/src/tui/error.rs
+++ b/src/tui/error.rs
@@ -39,6 +39,9 @@ pub(crate) enum TuiError {
     #[error("top tuxel in stack not found")]
     TopTuxelNotFound,
 
+    #[error("drawbuffer translation failed: {0}")]
+    DrawBufferTranslationFailed(String),
+
     #[error("io error")]
     StdIOError(#[from] std::io::Error),
 

--- a/src/tui/error.rs
+++ b/src/tui/error.rs
@@ -32,6 +32,9 @@ pub(crate) enum TuiError {
     #[error("invalid translation")]
     InvalidTranslation,
 
+    #[error("top tuxel in stack not found")]
+    TopTuxelNotFound,
+
     #[error("io error")]
     StdIOError(#[from] std::io::Error),
 

--- a/src/tui/error.rs
+++ b/src/tui/error.rs
@@ -3,11 +3,60 @@ use thiserror;
 /// The Result type for tui48.
 pub(crate) type Result<T> = std::result::Result<T, TuiError>;
 
-#[derive(thiserror::Error, Debug)]
-pub(crate) enum TuiError {
-    #[error("terminal too small, required minimum size {0} x {1}")]
-    TerminalTooSmall(usize, usize),
+pub struct TuiError {
+    bt: std::backtrace::Backtrace,
+    pub(crate) inner: InnerError,
+}
 
+impl std::fmt::Debug for TuiError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{0:?}\n{1}", self.inner, self.bt)
+    }
+}
+
+impl std::fmt::Display for TuiError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{0:?}\n{1}", self.inner, self.bt)
+    }
+}
+
+impl std::error::Error for TuiError {}
+
+impl From<std::sync::mpsc::SendError<crate::tui::geometry::Idx>> for TuiError {
+    fn from(inner: std::sync::mpsc::SendError<crate::tui::geometry::Idx>) -> TuiError {
+        InnerError::IdxSendError(inner).into()
+    }
+}
+
+impl From<std::sync::mpsc::SendError<crate::tui::tuxel::Tuxel>> for TuiError {
+    fn from(inner: std::sync::mpsc::SendError<crate::tui::tuxel::Tuxel>) -> TuiError {
+        InnerError::TuxelSendError(inner).into()
+    }
+}
+
+impl From<std::io::Error> for TuiError {
+    fn from(inner: std::io::Error) -> TuiError {
+        InnerError::StdIOError(inner).into()
+    }
+}
+
+impl From<anyhow::Error> for TuiError {
+    fn from(inner: anyhow::Error) -> TuiError {
+        InnerError::AnyhowError { source: inner }.into()
+    }
+}
+
+impl From<InnerError> for TuiError {
+    fn from(inner: InnerError) -> Self {
+        Self {
+            bt: std::backtrace::Backtrace::capture(),
+            inner,
+        }
+    }
+}
+
+#[derive(thiserror::Error, Debug)]
+pub(crate) enum InnerError {
     #[error("cell already owned")]
     CellAlreadyOwned,
 
@@ -29,7 +78,9 @@ pub(crate) enum TuiError {
     #[error("tuxel channel send failed")]
     TuxelSendError(#[from] std::sync::mpsc::SendError<crate::tui::tuxel::Tuxel>),
 
-    #[error("invalid translation \n\tmagnitude: {mag:?} \n\tdirection: {dir:?} \n\trectangle: {rect:?}")]
+    #[error(
+        "invalid translation \n\tmagnitude: {mag:?} \n\tdirection: {dir:?} \n\trectangle: {rect:?}"
+    )]
     InvalidVectorTranslation {
         mag: usize,
         dir: super::geometry::Direction,

--- a/src/tui/error.rs
+++ b/src/tui/error.rs
@@ -16,7 +16,7 @@ impl std::fmt::Debug for TuiError {
 
 impl std::fmt::Display for TuiError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{0:?}\n{1}", self.inner, self.bt)
+        write!(f, "{0}\n{1}", self.inner, self.bt)
     }
 }
 

--- a/src/tui/error.rs
+++ b/src/tui/error.rs
@@ -63,13 +63,13 @@ pub(crate) enum InnerError {
     #[error("{0}ward translation impossible")]
     TranslationImpossible(super::geometry::Direction),
 
-    #[error("out of bounds x - {0}")]
+    #[error("out of bounds x: {0}")]
     OutOfBoundsX(usize),
 
-    #[error("out of bounds y - {0}")]
+    #[error("out of bounds y: {0}")]
     OutOfBoundsY(usize),
 
-    #[error("out of bounds z - {0}")]
+    #[error("out of bounds z: {0}")]
     OutOfBoundsZ(usize),
 
     #[error("idx channel send failed")]

--- a/src/tui/error.rs
+++ b/src/tui/error.rs
@@ -29,8 +29,12 @@ pub(crate) enum TuiError {
     #[error("tuxel channel send failed")]
     TuxelSendError(#[from] std::sync::mpsc::SendError<crate::tui::tuxel::Tuxel>),
 
-    #[error("invalid translation")]
-    InvalidTranslation,
+    #[error("invalid translation \n\tmagnitude: {mag:?} \n\tdirection: {dir:?} \n\trectangle: {rect:?}")]
+    InvalidVectorTranslation {
+        mag: usize,
+        dir: super::geometry::Direction,
+        rect: super::geometry::Rectangle,
+    },
 
     #[error("top tuxel in stack not found")]
     TopTuxelNotFound,

--- a/src/tui/events.rs
+++ b/src/tui/events.rs
@@ -1,4 +1,5 @@
 use super::error::Result;
+use super::geometry::Direction;
 
 pub(crate) trait EventSource {
     fn next_event(&self) -> Result<Event>;
@@ -12,12 +13,4 @@ pub(crate) enum Event {
 pub(crate) enum UserInput {
     Direction(Direction),
     Quit,
-}
-
-/// Direction represents the direction indicated by the player input.
-pub(crate) enum Direction {
-    Left,
-    Right,
-    Up,
-    Down,
 }

--- a/src/tui/geometry.rs
+++ b/src/tui/geometry.rs
@@ -145,12 +145,12 @@ impl Iterator for Indices {
                 self.current_x = 0;
                 self.current_y += 1;
                 Some(idx)
-            },
+            }
             (x, y) if (x < self.to_x) => {
                 let idx = Idx(x, y, self.z);
                 self.current_x += 1;
                 Some(idx)
-            },
+            }
             (_, _) => unreachable!(),
         }
     }

--- a/src/tui/geometry.rs
+++ b/src/tui/geometry.rs
@@ -189,12 +189,7 @@ mod test {
         rectangle(0, 10, 0, 5, 5,),
         rectangle(0, 9, 0, 5, 5,)
     )]
-    #[case::move_up_to_zero(
-        1,
-        Direction::Up,
-        rectangle(0, 1, 0, 5, 5,),
-        rectangle(0, 0, 0, 5, 5,)
-    )]
+    #[case::move_up_to_zero(1, Direction::Up, rectangle(0, 1, 0, 5, 5,), rectangle(0, 0, 0, 5, 5,))]
     #[case::move_up_already_at_zero(
         1,
         Direction::Up,

--- a/src/tui/geometry.rs
+++ b/src/tui/geometry.rs
@@ -68,6 +68,12 @@ impl Rectangle {
         self.1 .1
     }
 
+    #[cfg(test)]
+    #[inline(always)]
+    pub(crate) fn dimensions(&self) -> (usize, usize) {
+        (self.width(), self.height())
+    }
+
     #[inline(always)]
     pub(crate) fn x(&self) -> usize {
         self.0 .0

--- a/src/tui/geometry.rs
+++ b/src/tui/geometry.rs
@@ -72,7 +72,7 @@ impl Rectangle {
     }
 
     #[inline(always)]
-    pub(crate) fn translate(&mut self, mag: usize, dir: Direction) -> Result<()> {
+    pub(crate) fn translate(&mut self, mag: usize, dir: &Direction) -> Result<()> {
         match dir {
             Direction::Left if self.x() > mag => self.0 .0 -= mag,
             Direction::Left if self.x() <= mag => self.0 .0 = 0,
@@ -99,7 +99,7 @@ impl Rectangle {
     #[inline(always)]
     pub(crate) fn contains_or_err(&self, idx: &Idx) -> Result<()> {
         if idx.x() < self.x() || idx.x() > self.x() + self.width() {
-            return Err(TuiError::OutOfBoundsY(idx.x()));
+            return Err(TuiError::OutOfBoundsX(idx.x()));
         }
         if idx.y() < self.y() || idx.y() > self.y() + self.height() {
             return Err(TuiError::OutOfBoundsY(idx.y()));

--- a/src/tui/geometry.rs
+++ b/src/tui/geometry.rs
@@ -235,6 +235,8 @@ impl std::fmt::Display for Direction {
 
 #[cfg(test)]
 mod test {
+    use std::collections::BTreeSet;
+
     use super::*;
     use rstest::*;
 
@@ -295,6 +297,43 @@ mod test {
         let mut updated = initial.clone();
         updated.translate(magnitude, &direction)?;
         assert_eq!(expected, updated);
+        Ok(())
+    }
+
+    #[rstest]
+    #[case::simple(
+        rectangle(0, 0, 0, 2, 2),
+        BTreeSet::from([(0,0), (0,1), (1,0), (1,1)]),
+    )]
+    fn rectangle_to_indices(
+        #[case] rectangle: Rectangle,
+        #[case] expected_indices: BTreeSet<(usize, usize)>,
+    ) -> Result<()> {
+        let mut actual_indices: BTreeSet<(usize, usize)> = BTreeSet::new();
+
+        let rectangle_indices: Indices = rectangle.into();
+        for idx in rectangle_indices {
+            actual_indices.insert((idx.x(), idx.y()));
+        }
+
+        // use set logic to verify actual and expected indices are correct
+        let only_in_actual = actual_indices
+            .difference(&expected_indices)
+            .collect::<BTreeSet<_>>();
+        let only_in_expected = expected_indices
+            .difference(&actual_indices)
+            .collect::<BTreeSet<_>>();
+        assert!(
+            only_in_actual.len() == 0,
+            "\nFAILED BECAUSE - missing changed indices in the expected set:\n{:?}",
+            &only_in_actual
+        );
+        assert!(
+            only_in_expected.len() == 0,
+            "\nFAILED BECAUSE - missing changed indices in the actual set:\n{:?}",
+            &only_in_expected
+        );
+
         Ok(())
     }
 }

--- a/src/tui/geometry.rs
+++ b/src/tui/geometry.rs
@@ -167,6 +167,7 @@ impl From<Rectangle> for Indices {
     fn from(r: Rectangle) -> Indices {
         Indices {
             z: r.z(),
+            from_x: r.x(),
             current_x: r.x(),
             current_y: r.y(),
             to_x: r.x() + r.width(),
@@ -178,20 +179,19 @@ impl From<Rectangle> for Indices {
 impl Iterator for Indices {
     type Item = Idx;
     fn next(&mut self) -> Option<Self::Item> {
-        match (self.current_x, self.current_y) {
-            (x, y) if (x == self.to_x && y == self.to_y) => None,
-            (x, y) if (x == self.to_x && y < self.to_y) => {
-                let idx = Idx(x, y, self.z);
-                self.current_x = 0;
-                self.current_y += 1;
-                Some(idx)
-            }
-            (x, y) if (x < self.to_x) => {
-                let idx = Idx(x, y, self.z);
-                self.current_x += 1;
-                Some(idx)
-            }
-            (_, _) => unreachable!(),
+        if self.current_x == self.to_x && self.current_y == self.to_y {
+            None
+        } else if self.current_x == self.to_x && self.current_y < self.to_y {
+            let idx = Idx(self.current_x, self.current_y, self.z);
+            self.current_x = self.from_x;
+            self.current_y += 1;
+            Some(idx)
+        } else if self.current_x < self.to_x {
+            let idx = Idx(self.current_x, self.current_y, self.z);
+            self.current_x += 1;
+            Some(idx)
+        } else {
+            unreachable!();
         }
     }
 }

--- a/src/tui/geometry.rs
+++ b/src/tui/geometry.rs
@@ -72,7 +72,8 @@ impl Rectangle {
             Position::TopRight => (self.width() - 1, 0),
             Position::BottomLeft => (0, self.height() - 1),
             Position::BottomRight => (self.width() - 1, self.height() - 1),
-            Position::Idx(x, y) => (*x, *y),
+            Position::Coordinates(x, y) => (*x, *y),
+            Position::Idx(Idx(x, y, _z)) => (*x, *y),
         }
     }
 
@@ -161,7 +162,14 @@ pub(crate) enum Position {
     TopRight,
     BottomLeft,
     BottomRight,
-    Idx(usize, usize),
+    Coordinates(usize, usize),
+    Idx(Idx),
+}
+
+impl From<Idx> for Position {
+    fn from(idx: Idx) -> Self {
+        Self::Idx(idx)
+    }
 }
 
 /// Direction represents the direction indicated by the player.

--- a/src/tui/geometry.rs
+++ b/src/tui/geometry.rs
@@ -1,6 +1,25 @@
+use super::error::{Result, TuiError};
+
 /// Idx encapsulates the x, y, and z coordinates of a Tuxel-based shape.
 #[derive(Clone, Default)]
 pub(crate) struct Idx(pub usize, pub usize, pub usize);
+
+impl Idx {
+    #[inline(always)]
+    pub(crate) fn x(&self) -> usize {
+        self.0
+    }
+
+    #[inline(always)]
+    pub(crate) fn y(&self) -> usize {
+        self.1
+    }
+
+    #[inline(always)]
+    pub(crate) fn z(&self) -> usize {
+        self.2
+    }
+}
 
 #[derive(Clone, Default)]
 pub(crate) struct Bounds2D(pub usize, pub usize);
@@ -9,18 +28,22 @@ pub(crate) struct Bounds2D(pub usize, pub usize);
 pub(crate) struct Rectangle(pub Idx, pub Bounds2D);
 
 impl Rectangle {
+    #[inline(always)]
     pub(crate) fn width(&self) -> usize {
         self.1 .0
     }
 
+    #[inline(always)]
     pub(crate) fn height(&self) -> usize {
         self.1 .1
     }
 
+    #[inline(always)]
     pub(crate) fn x(&self) -> usize {
         self.0 .0
     }
 
+    #[inline(always)]
     pub(crate) fn y(&self) -> usize {
         self.0 .1
     }
@@ -35,8 +58,20 @@ impl Rectangle {
         }
     }
 
+    #[inline(always)]
     pub(crate) fn extents(&self) -> (usize, usize) {
         (self.0 .0 + self.1 .0, self.0 .1 + self.1 .1)
+    }
+
+    #[inline(always)]
+    pub(crate) fn contains_or_err(&self, idx: &Idx) -> Result<()> {
+        if idx.x() < self.x() || idx.x() > self.x() + self.width() {
+            return Err(TuiError::OutOfBoundsY(idx.x()))
+        }
+        if idx.y() < self.y() || idx.y() > self.y() + self.height() {
+            return Err(TuiError::OutOfBoundsY(idx.y()))
+        }
+        Ok(())
     }
 }
 
@@ -58,3 +93,14 @@ pub(crate) enum Direction {
     Down,
 }
 
+impl std::fmt::Display for Direction {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let s = match self {
+            Self::Left => "left",
+            Self::Right => "right",
+            Self::Up => "up",
+            Self::Down => "down",
+        };
+        write!(f, "{}", s)
+    }
+}

--- a/src/tui/geometry.rs
+++ b/src/tui/geometry.rs
@@ -221,17 +221,6 @@ pub(crate) enum Direction {
     Down,
 }
 
-impl Direction {
-    pub(crate) fn opposite(&self) -> Direction {
-        match self {
-            Self::Left => Self::Right,
-            Self::Right => Self::Left,
-            Self::Up => Self::Down,
-            Self::Down => Self::Up,
-        }
-    }
-}
-
 impl std::fmt::Display for Direction {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let s = match self {

--- a/src/tui/geometry.rs
+++ b/src/tui/geometry.rs
@@ -59,6 +59,18 @@ impl Rectangle {
     }
 
     #[inline(always)]
+    pub(crate) fn translate(&mut self, mag: usize, dir: Direction) -> Result<()> {
+        match dir {
+            Direction::Left if self.0 .0 != 0 => self.0 .0 = self.0 .0 - 1,
+            Direction::Right => self.0 .0 = self.0 .0 + 1,
+            Direction::Up if self.0 .1 != 0 => self.0 .1 = self.0 .1 - 1,
+            Direction::Down => self.0 .1 = self.0 .1 + 1,
+            _ => return Err(TuiError::InvalidTranslation),
+        }
+        Ok(())
+    }
+
+    #[inline(always)]
     pub(crate) fn extents(&self) -> (usize, usize) {
         (self.0 .0 + self.1 .0, self.0 .1 + self.1 .1)
     }
@@ -66,10 +78,10 @@ impl Rectangle {
     #[inline(always)]
     pub(crate) fn contains_or_err(&self, idx: &Idx) -> Result<()> {
         if idx.x() < self.x() || idx.x() > self.x() + self.width() {
-            return Err(TuiError::OutOfBoundsY(idx.x()))
+            return Err(TuiError::OutOfBoundsY(idx.x()));
         }
         if idx.y() < self.y() || idx.y() > self.y() + self.height() {
-            return Err(TuiError::OutOfBoundsY(idx.y()))
+            return Err(TuiError::OutOfBoundsY(idx.y()));
         }
         Ok(())
     }

--- a/src/tui/geometry.rs
+++ b/src/tui/geometry.rs
@@ -56,6 +56,11 @@ impl Rectangle {
     }
 
     #[inline(always)]
+    pub(crate) fn z(&self) -> usize {
+        self.0 .2
+    }
+
+    #[inline(always)]
     pub(crate) fn y(&self) -> usize {
         self.0 .1
     }
@@ -105,6 +110,49 @@ impl Rectangle {
             return Err(TuiError::OutOfBoundsY(idx.y()));
         }
         Ok(())
+    }
+}
+
+pub(crate) struct Indices {
+    current_x: usize,
+    to_x: usize,
+
+    current_y: usize,
+    to_y: usize,
+
+    z: usize,
+}
+
+impl From<Rectangle> for Indices {
+    fn from(r: Rectangle) -> Indices {
+        Indices {
+            z: r.z(),
+            current_x: r.x(),
+            current_y: r.y(),
+            to_x: r.x() + r.width(),
+            to_y: r.y() + r.height(),
+        }
+    }
+}
+
+impl Iterator for Indices {
+    type Item = Idx;
+    fn next(&mut self) -> Option<Self::Item> {
+        match (self.current_x, self.current_y) {
+            (x, y) if (x == self.to_x && y == self.to_y) => None,
+            (x, y) if (x == self.to_x && y < self.to_y) => {
+                let idx = Idx(x, y, self.z);
+                self.current_x = 0;
+                self.current_y += 1;
+                Some(idx)
+            },
+            (x, y) if (x < self.to_x) => {
+                let idx = Idx(x, y, self.z);
+                self.current_x += 1;
+                Some(idx)
+            },
+            (_, _) => unreachable!(),
+        }
     }
 }
 

--- a/src/tui/geometry.rs
+++ b/src/tui/geometry.rs
@@ -265,7 +265,7 @@ mod test {
         #[case] expected: Rectangle,
     ) -> Result<()> {
         let mut updated = initial.clone();
-        updated.translate(magnitude, direction)?;
+        updated.translate(magnitude, &direction)?;
         assert_eq!(expected, updated);
         Ok(())
     }

--- a/src/tui/geometry.rs
+++ b/src/tui/geometry.rs
@@ -1,4 +1,4 @@
-use super::error::{Result, TuiError};
+use super::error::{Result, InnerError};
 
 /// Idx encapsulates the x, y, and z coordinates of a Tuxel-based shape.
 #[derive(Clone, Debug, Default, PartialEq)]
@@ -87,11 +87,11 @@ impl Rectangle {
             Direction::Up if self.y() <= mag => self.0 .1 = 0,
             Direction::Down => self.0 .1 += mag,
             _ => {
-                return Err(TuiError::InvalidVectorTranslation {
+                return Err(InnerError::InvalidVectorTranslation {
                     mag,
                     dir: dir.clone(),
                     rect: self.clone(),
-                })
+                }.into())
             }
         }
         Ok(())
@@ -105,10 +105,10 @@ impl Rectangle {
     #[inline(always)]
     pub(crate) fn contains_or_err(&self, idx: &Idx) -> Result<()> {
         if idx.x() < self.x() || idx.x() > self.x() + self.width() {
-            return Err(TuiError::OutOfBoundsX(idx.x()));
+            return Err(InnerError::OutOfBoundsX(idx.x()).into());
         }
         if idx.y() < self.y() || idx.y() > self.y() + self.height() {
-            return Err(TuiError::OutOfBoundsY(idx.y()));
+            return Err(InnerError::OutOfBoundsY(idx.y()).into());
         }
         Ok(())
     }

--- a/src/tui/geometry.rs
+++ b/src/tui/geometry.rs
@@ -122,18 +122,38 @@ impl Rectangle {
     }
 
     #[inline(always)]
-    pub(crate) fn contains_or_err(&self, idx: &Idx) -> Result<()> {
-        if idx.x() < self.x() || idx.x() > self.x() + self.width() {
-            return Err(InnerError::OutOfBoundsX(idx.x()).into());
+    pub(crate) fn contains_or_err(&self, geo: Geometry) -> Result<()> {
+        match geo {
+            Geometry::Idx(idx) => {
+                if idx.x() < self.x() || idx.x() > self.x() + self.width() {
+                    return Err(InnerError::OutOfBoundsX(idx.x()).into());
+                }
+                if idx.y() < self.y() || idx.y() > self.y() + self.height() {
+                    return Err(InnerError::OutOfBoundsY(idx.y()).into());
+                }
+                Ok(())
+            }
+            Geometry::Rectangle(rect) => {
+                let (x_extent, y_extent) = rect.extents();
+                if x_extent > self.width() {
+                    return Err(InnerError::OutOfBoundsX(x_extent).into());
+                }
+                if y_extent > self.height() {
+                    return Err(InnerError::OutOfBoundsY(y_extent).into());
+                }
+                Ok(())
+            }
         }
-        if idx.y() < self.y() || idx.y() > self.y() + self.height() {
-            return Err(InnerError::OutOfBoundsY(idx.y()).into());
-        }
-        Ok(())
     }
 }
 
+pub(crate) enum Geometry<'a> {
+    Idx(&'a Idx),
+    Rectangle(&'a Rectangle),
+}
+
 pub(crate) struct Indices {
+    from_x: usize,
     current_x: usize,
     to_x: usize,
 

--- a/src/tui/geometry.rs
+++ b/src/tui/geometry.rs
@@ -1,8 +1,14 @@
-use super::error::{Result, InnerError};
+use super::error::{InnerError, Result};
 
 /// Idx encapsulates the x, y, and z coordinates of a Tuxel-based shape.
 #[derive(Clone, Debug, Default, PartialEq)]
 pub(crate) struct Idx(pub usize, pub usize, pub usize);
+
+impl std::fmt::Display for Idx {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "idx({0},{1},{2})", self.0, self.1, self.2)
+    }
+}
 
 impl Idx {
     #[inline(always)]
@@ -24,6 +30,12 @@ impl Idx {
 #[derive(Clone, Debug, Default, PartialEq)]
 pub(crate) struct Bounds2D(pub usize, pub usize);
 
+impl std::fmt::Display for Bounds2D {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "dims({0}, {1})", self.0, self.1)
+    }
+}
+
 impl Bounds2D {
     #[inline(always)]
     pub(crate) fn width(&self) -> usize {
@@ -38,6 +50,12 @@ impl Bounds2D {
 
 #[derive(Clone, Debug, Default, PartialEq)]
 pub(crate) struct Rectangle(pub Idx, pub Bounds2D);
+
+impl std::fmt::Display for Rectangle {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "rect({0} {1})", self.0, self.1,)
+    }
+}
 
 impl Rectangle {
     #[inline(always)]
@@ -91,7 +109,8 @@ impl Rectangle {
                     mag,
                     dir: dir.clone(),
                     rect: self.clone(),
-                }.into())
+                }
+                .into())
             }
         }
         Ok(())

--- a/src/tui/geometry.rs
+++ b/src/tui/geometry.rs
@@ -48,3 +48,13 @@ pub(crate) enum Position {
     Idx(usize, usize),
 }
 
+/// Direction represents the direction indicated by the player.
+#[derive(Clone, Debug, Default)]
+pub(crate) enum Direction {
+    #[default]
+    Left,
+    Right,
+    Up,
+    Down,
+}
+

--- a/src/tui/geometry.rs
+++ b/src/tui/geometry.rs
@@ -170,8 +170,8 @@ impl From<Rectangle> for Indices {
             from_x: r.x(),
             current_x: r.x(),
             current_y: r.y(),
-            to_x: r.x() + r.width(),
-            to_y: r.y() + r.height(),
+            to_x: r.x() + r.width() - 1,
+            to_y: r.y() + r.height() - 1,
         }
     }
 }
@@ -179,16 +179,16 @@ impl From<Rectangle> for Indices {
 impl Iterator for Indices {
     type Item = Idx;
     fn next(&mut self) -> Option<Self::Item> {
-        if self.current_x == self.to_x && self.current_y == self.to_y {
+        if self.current_y > self.to_y {
             None
-        } else if self.current_x == self.to_x && self.current_y < self.to_y {
-            let idx = Idx(self.current_x, self.current_y, self.z);
-            self.current_x = self.from_x;
-            self.current_y += 1;
-            Some(idx)
         } else if self.current_x < self.to_x {
             let idx = Idx(self.current_x, self.current_y, self.z);
             self.current_x += 1;
+            Some(idx)
+        } else if self.current_x == self.to_x && self.current_y <= self.to_y {
+            let idx = Idx(self.current_x, self.current_y, self.z);
+            self.current_x = self.from_x;
+            self.current_y += 1;
             Some(idx)
         } else {
             unreachable!();

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -1,5 +1,6 @@
 pub(crate) mod canvas;
 pub(crate) mod drawbuffer;
+pub(crate) mod colors;
 pub(crate) mod geometry;
 pub(crate) mod tuxel;
 pub(crate) mod crossterm;

--- a/src/tui/renderer.rs
+++ b/src/tui/renderer.rs
@@ -5,4 +5,5 @@ pub(crate) trait Renderer {
     fn size_hint(&self) -> Result<(u16, u16)>;
     fn render(&mut self, c: &Canvas) -> Result<()>;
     fn clear(&mut self, c: &Canvas) -> Result<()>;
+    fn recover(&mut self);
 }

--- a/src/tui/tuxel.rs
+++ b/src/tui/tuxel.rs
@@ -9,34 +9,7 @@ pub(crate) struct Tuxel {
     content: char,
     idx: Idx,
     modifiers: Vec<Modifier>,
-    shared_modifiers: SharedModifiers,
-}
-
-impl Tuxel {
-    pub(crate) fn set_content(&mut self, c: char) {
-        self.active = true;
-        self.content = c;
-    }
-
-    pub(crate) fn coordinates(&self) -> (usize, usize) {
-        (self.idx.0, self.idx.1)
-    }
-
-    pub(crate) fn modifiers(&self) -> Vec<Modifier> {
-        let parent_modifiers = &mut self.shared_modifiers.lock();
-        let mut modifiers: Vec<Modifier> = self.modifiers.clone();
-        parent_modifiers.append(&mut modifiers);
-        parent_modifiers.to_vec()
-    }
-
-    pub(crate) fn clear(&mut self) {
-        self.content = ' ';
-        self.modifiers.clear();
-    }
-
-    pub(crate) fn active(&self) -> bool {
-        self.active
-    }
+    pub(crate) shared_modifiers: Option<SharedModifiers>,
 }
 
 impl Tuxel {
@@ -49,8 +22,36 @@ impl Tuxel {
             content: '-',
             idx,
             modifiers: Vec::new(),
-            shared_modifiers: SharedModifiers::default(),
+            shared_modifiers: None,
         }
+    }
+
+    pub(crate) fn set_content(&mut self, c: char) {
+        self.active = true;
+        self.content = c;
+    }
+
+    pub(crate) fn coordinates(&self) -> (usize, usize) {
+        (self.idx.0, self.idx.1)
+    }
+
+    pub(crate) fn modifiers(&self) -> Vec<Modifier> {
+        let mut modifiers = match &self.shared_modifiers {
+            Some(ms) => ms.lock().clone(),
+            None => Vec::new(),
+        };
+        modifiers.append(&mut self.modifiers.clone());
+        modifiers.to_vec()
+    }
+
+    pub(crate) fn clear(&mut self) {
+        self.content = ' ';
+        self.modifiers.clear();
+        self.shared_modifiers = None;
+    }
+
+    pub(crate) fn active(&self) -> bool {
+        self.active
     }
 
     pub(crate) fn content(&self) -> char {

--- a/src/tui/tuxel.rs
+++ b/src/tui/tuxel.rs
@@ -59,11 +59,14 @@ impl Tuxel {
     pub(crate) fn idx(&self) -> Idx {
         self.idx.clone()
     }
+
+    pub(crate) fn set_idx(&mut self, idx: &Idx) {
+        self.idx = idx.clone()
+    }
 }
 
 impl std::fmt::Display for Tuxel {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", self.content())?;
-        Ok(())
+        write!(f, "{}", self.content())
     }
 }

--- a/src/tui/tuxel.rs
+++ b/src/tui/tuxel.rs
@@ -1,5 +1,3 @@
-use std::sync::{Arc, Mutex, MutexGuard};
-
 use super::canvas::{Modifier, SharedModifiers};
 use super::geometry::Idx;
 

--- a/src/tui/tuxel.rs
+++ b/src/tui/tuxel.rs
@@ -1,13 +1,13 @@
-use super::canvas::{Modifier, SharedModifiers};
 use super::geometry::Idx;
+use super::colors::Rgb;
 
 #[derive(Default)]
 pub(crate) struct Tuxel {
     active: bool,
     content: char,
     idx: Idx,
-    modifiers: Vec<Modifier>,
-    pub(crate) shared_modifiers: Option<SharedModifiers>,
+    fgcolor: Option<Rgb>,
+    bgcolor: Option<Rgb>,
 }
 
 impl Tuxel {
@@ -18,9 +18,9 @@ impl Tuxel {
             //content: '\u{2566}',
             active: false,
             content: '-',
+            fgcolor: None,
+            bgcolor: None,
             idx,
-            modifiers: Vec::new(),
-            shared_modifiers: None,
         }
     }
 
@@ -33,19 +33,9 @@ impl Tuxel {
         (self.idx.0, self.idx.1)
     }
 
-    pub(crate) fn modifiers(&self) -> Vec<Modifier> {
-        let mut modifiers = match &self.shared_modifiers {
-            Some(ms) => ms.lock().clone(),
-            None => Vec::new(),
-        };
-        modifiers.append(&mut self.modifiers.clone());
-        modifiers.to_vec()
-    }
-
     pub(crate) fn clear(&mut self) {
+        self.active = false;
         self.content = ' ';
-        self.modifiers.clear();
-        self.shared_modifiers = None;
     }
 
     pub(crate) fn active(&self) -> bool {
@@ -62,6 +52,10 @@ impl Tuxel {
 
     pub(crate) fn set_idx(&mut self, idx: &Idx) {
         self.idx = idx.clone()
+    }
+
+    pub(crate) fn colors(&self) -> (Option<Rgb>, Option<Rgb>) {
+        (self.fgcolor.clone(), self.bgcolor.clone())
     }
 }
 

--- a/src/tui48.rs
+++ b/src/tui48.rs
@@ -215,7 +215,7 @@ impl Tui48Board {
             buf,
         };
 
-        let rectangle = Tui48Board::tile_rectangle(to_idx.0, to_idx.1, UPPER_ANIMATION_LAYER_IDX);
+        let rectangle = Tui48Board::tile_rectangle(to_idx.x(), to_idx.y(), LOWER_ANIMATION_LAYER_IDX);
         let st = SlidingTile::new(t, rectangle);
 
         Ok(st)
@@ -224,19 +224,19 @@ impl Tui48Board {
     fn setup_animation(&mut self, hint: AnimationHint) -> Result<()> {
         for (idx, hint) in hint.hints() {
             let mut slot = self.get_slot(&idx)?;
-            match hint {
+            let new_slot = match hint {
                 Hint::ToIdx(to_idx) => {
-                    slot = Slot::to_sliding(slot, to_idx, None)?;
+                    Slot::to_sliding(slot, to_idx, None)?
                 }
                 Hint::NewValueToIdx(value, to_idx) => {
-                    slot = Slot::to_sliding(slot, to_idx, Some(value))?;
+                    Slot::to_sliding(slot, to_idx, Some(value))?
                 }
                 Hint::NewTile(value, slide_direction) => {
                     let t = self.new_sliding_tile(&idx, value, &slide_direction)?;
-                    slot = Slot::Sliding(t);
+                    Slot::Sliding(t)
                 }
-            }
-            self.put_slot(&idx, slot)?;
+            };
+            self.put_slot(&idx, new_slot)?;
         }
         Ok(())
     }

--- a/src/tui48.rs
+++ b/src/tui48.rs
@@ -274,7 +274,18 @@ impl Slot {
     }
 
     fn to_static(this: Self) -> Result<Self> {
-        Ok(this)
+        // only allow static tiles to be converted to sliding
+        if let Self::Static(_) = this {
+            return Ok(this)
+        }
+
+        if let Self::Sliding(st) = this {
+            let t = st.to_tile();
+            t.buf.switch_layer(TILE_LAYER_IDX)?;
+            return Ok(Slot::Static(t))
+        }
+
+        Err(Error::CannotConvertToStatic)
     }
 }
 
@@ -292,6 +303,12 @@ impl Tile {
 struct SlidingTile {
     inner: Tile,
     to_idx: BoardIdx,
+}
+
+impl SlidingTile {
+    fn to_tile(self) -> Tile {
+        self.inner
+    }
 }
 
 struct Colors {

--- a/src/tui48.rs
+++ b/src/tui48.rs
@@ -336,8 +336,8 @@ impl Slot {
 
     fn is_sliding(this: &Self) -> bool {
         match this {
-            _ => false,
             Slot::Sliding(_) => true,
+            _ => false,
         }
     }
 

--- a/src/tui48.rs
+++ b/src/tui48.rs
@@ -889,7 +889,6 @@ impl<R: Renderer, E: EventSource> Tui48<R, E> {
                     self.renderer.clear(&self.canvas)?;
                 }
             }
-            self.canvas.draw_all()?;
         }
         Ok(())
     }

--- a/src/tui48.rs
+++ b/src/tui48.rs
@@ -340,6 +340,7 @@ impl Slot {
             Slot::Sliding(_) => true,
         }
     }
+
     fn is_animating(this: &Self) -> bool {
         match this {
             Slot::Empty => false,

--- a/src/tui48.rs
+++ b/src/tui48.rs
@@ -313,10 +313,24 @@ impl std::fmt::Display for Tui48Board {
                 .enumerate()
                 .map(|(x, slot)| {
                     let slot = match slot {
-                        Slot::Empty => self.moving_slots.iter().find(|s| match s {
-                            Slot::Sliding(st) => st.inner.idx.x() == x && st.inner.idx.y() == y,
-                            _ => false,
-                        }),
+                        Slot::Empty => self
+                            .moving_slots
+                            .iter()
+                            .find(|s| match s {
+                                Slot::Sliding(st) => st.inner.idx.x() == x && st.inner.idx.y() == y,
+                                _ => false,
+                            })
+                            .or_else(|| {
+                                self.done_slots
+                                    .iter()
+                                    .find(|(_, s)| match s {
+                                        Slot::Sliding(st) => {
+                                            st.inner.idx.x() == x && st.inner.idx.y() == y
+                                        }
+                                        _ => false,
+                                    })
+                                    .map(|(_, s)| s)
+                            }),
                         _ => Some(slot),
                     };
                     if let Some(s) = slot {

--- a/src/tui48.rs
+++ b/src/tui48.rs
@@ -292,43 +292,43 @@ impl AnimatedTui48Board {
         ) {
             (0, 0) => Ok(true), //no translation necessary
             (x, y) if x != 0 && y != 0 && x.abs() > y.abs() && x > 0 => {
-                moving_buf.translate(1, Direction::Left)?;
+                moving_buf.translate(Direction::Left)?;
                 Ok(true)
             }
             (x, y) if x != 0 && y != 0 && x.abs() > y.abs() && x < 0 => {
-                moving_buf.translate(1, Direction::Right)?;
+                moving_buf.translate(Direction::Right)?;
                 Ok(true)
             }
             (x, y) if x != 0 && y != 0 && x.abs() < y.abs() && y > 0 => {
-                moving_buf.translate(1, Direction::Up)?;
+                moving_buf.translate(Direction::Up)?;
                 Ok(true)
             }
             (x, y) if x != 0 && y != 0 && x.abs() < y.abs() && y < 0 => {
-                moving_buf.translate(1, Direction::Down)?;
+                moving_buf.translate(Direction::Down)?;
                 Ok(true)
             }
             (x, y) if x != 0 && y != 0 && x.abs() == y.abs() && y > 0 => {
-                moving_buf.translate(1, Direction::Up)?;
+                moving_buf.translate(Direction::Up)?;
                 Ok(true)
             }
             (x, y) if x != 0 && y != 0 && x.abs() == y.abs() && y < 0 => {
-                moving_buf.translate(1, Direction::Down)?;
+                moving_buf.translate(Direction::Down)?;
                 Ok(true)
             }
             (x, 0) if x > 0 => {
-                moving_buf.translate(1, Direction::Left)?;
+                moving_buf.translate(Direction::Left)?;
                 Ok(true)
             }
             (x, 0) if x < 0 => {
-                moving_buf.translate(1, Direction::Right)?;
+                moving_buf.translate(Direction::Right)?;
                 Ok(true)
             }
             (0, y) if y > 0 => {
-                moving_buf.translate(1, Direction::Up)?;
+                moving_buf.translate(Direction::Up)?;
                 Ok(true)
             }
             (0, y) if y < 0 => {
-                moving_buf.translate(1, Direction::Down)?;
+                moving_buf.translate(Direction::Down)?;
                 Ok(true)
             }
             _ => Ok(true),
@@ -376,7 +376,7 @@ impl AnimatedTui48Board {
 
         // 1 frame of buffer translation
         {
-            new_tile.borrow_mut().translate(1, from_dir.opposite())?;
+            new_tile.borrow_mut().translate(shift_dir)?;
         }
 
         Ok(true)

--- a/src/tui48.rs
+++ b/src/tui48.rs
@@ -398,7 +398,9 @@ impl SlidingTile {
             return Ok(false);
         }
 
-        if self.inner.buf.rectangle() == self.to_rectangle {
+        if self.inner.buf.rectangle().0.x() == self.to_rectangle.0.x()
+            && self.inner.buf.rectangle().0.y() == self.to_rectangle.0.y()
+        {
             // final frame
             self.inner.buf.switch_layer(TILE_LAYER_IDX)?;
             self.is_animating = false;

--- a/src/tui48.rs
+++ b/src/tui48.rs
@@ -484,7 +484,6 @@ impl Slot {
     }
 
     fn idx(&self) -> Result<BoardIdx> {
-        //BoardIdx::default()
         match self {
             Slot::Empty => unreachable!(),
             Slot::Static(t) => Ok(t.idx.clone()),

--- a/src/tui48.rs
+++ b/src/tui48.rs
@@ -693,6 +693,10 @@ struct Colors {
 static DEFAULT_COLORS: OnceLock<Colors> = OnceLock::new();
 
 pub(crate) fn init() -> Result<()> {
+    if let Some(p) = DEFAULT_COLORS.get() {
+        // already set, no need to do anything else
+        return Ok(());
+    }
     let bg_hue = 28.0;
     let fg_hue = bg_hue + 180.0;
     let defaults = Colors {
@@ -724,9 +728,8 @@ pub(crate) fn init() -> Result<()> {
                 }),
         ),
     };
-    DEFAULT_COLORS
-        .set(defaults)
-        .or(Err(Error::DefaultColorsAlreadySet))?;
+    let _ = DEFAULT_COLORS.set(defaults);
+
     Ok(())
 }
 

--- a/src/tui48.rs
+++ b/src/tui48.rs
@@ -617,8 +617,7 @@ impl std::fmt::Display for Tile {
             self.value,
             self.idx,
             self.buf.rectangle().0
-        );
-        Ok(())
+        )
     }
 }
 

--- a/src/tui48.rs
+++ b/src/tui48.rs
@@ -1,11 +1,11 @@
-use crate::engine::board::{Board, Direction as GameDirection};
-use crate::engine::round::Idx as BoardIdx;
+use crate::engine::board::Board;
+use crate::engine::round::{AnimationHint, Idx as BoardIdx, Round};
 
-use crate::tui::error::{TuiError, Result};
 use crate::tui::canvas::{Canvas, Modifier};
 use crate::tui::drawbuffer::DrawBuffer;
-use crate::tui::events::{Direction, Event, EventSource, UserInput};
-use crate::tui::geometry::{Bounds2D, Idx, Rectangle};
+use crate::tui::error::{Result, TuiError};
+use crate::tui::events::{Event, EventSource, UserInput};
+use crate::tui::geometry::{Bounds2D, Direction, Idx, Rectangle};
 use crate::tui::renderer::Renderer;
 
 struct Tui48Board {
@@ -144,7 +144,7 @@ impl<R: Renderer, E: EventSource> Tui48<R, E> {
                     match message_buf.take() {
                         Some(b) => {
                             drop(b);
-                        },
+                        }
                         None => (),
                     };
                     self.renderer.clear(&self.canvas)?;
@@ -153,15 +153,6 @@ impl<R: Renderer, E: EventSource> Tui48<R, E> {
             self.canvas.draw_all()?;
         }
         Ok(())
-    }
-}
-
-fn direction_to_game_direction(input: Direction) -> GameDirection {
-    match input {
-        Direction::Left => GameDirection::Left,
-        Direction::Right => GameDirection::Right,
-        Direction::Up => GameDirection::Up,
-        Direction::Down => GameDirection::Down,
     }
 }
 

--- a/src/tui48.rs
+++ b/src/tui48.rs
@@ -10,7 +10,6 @@ use crate::engine::round::{AnimationHint, Hint, Round};
 use super::error::{Error, Result};
 use crate::tui::canvas::{Canvas, Modifier};
 use crate::tui::drawbuffer::DrawBuffer;
-use crate::tui::error::TuiError;
 use crate::tui::events::{Event, EventSource, UserInput};
 use crate::tui::geometry::{Bounds2D, Direction, Idx, Rectangle};
 use crate::tui::renderer::Renderer;
@@ -81,7 +80,7 @@ impl Tui48Board {
         let (cwidth, cheight) = canvas.dimensions();
         let (x_extent, y_extent) = board_rectangle.extents();
         if cwidth < x_extent || cheight < y_extent {
-            return Err(TuiError::TerminalTooSmall(cwidth, cheight).into());
+            return Err(Error::TerminalTooSmall(cwidth, cheight).into());
         }
 
         let mut board = canvas.get_draw_buffer(board_rectangle)?;
@@ -599,9 +598,7 @@ impl<R: Renderer, E: EventSource> Tui48<R, E> {
         self.canvas = Canvas::new(width as usize, height as usize);
         self.tui_board = match Tui48Board::new(&self.board, &mut self.canvas) {
             Ok(tb) => Some(tb),
-            Err(Error::TuiError {
-                source: TuiError::TerminalTooSmall(_, _),
-            }) => None,
+            Err(Error::TerminalTooSmall(_, _)) => None,
             Err(e) => return Err(e),
         };
         Ok(())

--- a/src/tui48.rs
+++ b/src/tui48.rs
@@ -144,7 +144,6 @@ impl<R: Renderer, E: EventSource> Tui48<R, E> {
                     match message_buf.take() {
                         Some(b) => {
                             drop(b);
-                            self.canvas.reclaim();
                         },
                         None => (),
                     };
@@ -183,7 +182,6 @@ impl<R: Renderer, E: EventSource> Tui48<R, E> {
         if let Some(_hint) = self.board.shift(direction) {
             let tb = self.tui_board.take();
             drop(tb);
-            self.canvas.reclaim();
             self.tui_board = Some(Tui48Board::new(&self.board, &mut self.canvas)?);
         }
         Ok(())

--- a/src/tui48.rs
+++ b/src/tui48.rs
@@ -1,6 +1,4 @@
-use std::cell::RefCell;
 use std::collections::HashMap;
-use std::rc::Rc;
 use std::sync::OnceLock;
 
 use palette::{FromColor, Lch, Srgb};

--- a/src/tui48.rs
+++ b/src/tui48.rs
@@ -169,7 +169,6 @@ impl<R: Renderer, E: EventSource> Tui48<R, E> {
     }
 
     fn shift(&mut self, direction: Direction) -> Result<()> {
-        let direction = direction_to_game_direction(direction);
         if let Some(_hint) = self.board.shift(direction) {
             let tb = self.tui_board.take();
             drop(tb);

--- a/src/tui48.rs
+++ b/src/tui48.rs
@@ -202,7 +202,8 @@ impl Tui48Board {
                 r
             }
             Direction::Up => {
-                let r = Tui48Board::tile_rectangle(to_idx.x(), 4, LOWER_ANIMATION_LAYER_IDX);
+                let mut r = Tui48Board::tile_rectangle(to_idx.x(), 4, LOWER_ANIMATION_LAYER_IDX);
+                r.0 .1 -= 2;
                 r
             }
             Direction::Down => {

--- a/src/tui48.rs
+++ b/src/tui48.rs
@@ -603,7 +603,8 @@ impl SlidingTile {
             && self.inner.buf.rectangle().0.y() == self.to_rectangle.0.y()
         {
             // final frame
-            self.inner.buf.switch_layer(TILE_LAYER_IDX)?;
+            // don't move the drawbuffer to the tile layer, leave that for
+            // Tui48Board.teardown_animation
             if let Some(v) = self.new_value {
                 self.inner.value = v;
             }

--- a/src/tui48.rs
+++ b/src/tui48.rs
@@ -260,7 +260,7 @@ impl Tui48Board {
     }
 
     fn animate(&mut self) -> Result<bool> {
-        Ok(self
+        let should_continue = self
             .slots
             .iter_mut()
             .flatten()
@@ -268,7 +268,8 @@ impl Tui48Board {
             .map(|slot| slot.animate())
             .collect::<Result<Vec<bool>>>()?
             .iter()
-            .any(|b| *b))
+            .fold(false, |b, n| b | n);
+        Ok(should_continue)
     }
 }
 

--- a/src/tui48.rs
+++ b/src/tui48.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 use std::sync::OnceLock;
 
-use palette::{FromColor, Hsv, Srgb};
+use palette::{FromColor, Lch, Srgb};
 
 use crate::engine::board::Board;
 use crate::engine::round::Idx as BoardIdx;
@@ -148,76 +148,33 @@ pub(crate) fn init() -> Result<()> {
     let fg_hue = bg_hue + 180.0;
     let defaults = Colors {
         card_colors: HashMap::from_iter(
-            vec![
-                (
-                    2u16,
-                    Hsv::new(bg_hue, 0.0, 0.957),
-                    Hsv::new(fg_hue, 0.9, 0.5),
-                ),
-                (
-                    4u16,
-                    Hsv::new(bg_hue, 0.1, 0.957),
-                    Hsv::new(fg_hue, 0.9, 0.5),
-                ),
-                (
-                    8u16,
-                    Hsv::new(bg_hue, 0.2, 0.957),
-                    Hsv::new(fg_hue, 0.9, 0.5),
-                ),
-                (
-                    16u16,
-                    Hsv::new(bg_hue, 0.3, 0.957),
-                    Hsv::new(fg_hue, 0.9, 0.5),
-                ),
-                (
-                    32u16,
-                    Hsv::new(bg_hue, 0.4, 0.957),
-                    Hsv::new(fg_hue, 0.9, 0.5),
-                ),
-                (
-                    64u16,
-                    Hsv::new(bg_hue, 0.5, 0.957),
-                    Hsv::new(fg_hue, 0.9, 0.5),
-                ),
-                (
-                    128u16,
-                    Hsv::new(bg_hue, 0.6, 0.957),
-                    Hsv::new(fg_hue, 0.9, 0.5),
-                ),
-                (
-                    256u16,
-                    Hsv::new(bg_hue, 0.7, 0.957),
-                    Hsv::new(fg_hue, 0.9, 0.5),
-                ),
-                (
-                    512u16,
-                    Hsv::new(bg_hue, 0.8, 0.957),
-                    Hsv::new(fg_hue, 0.9, 0.5),
-                ),
-                (
-                    1024u16,
-                    Hsv::new(bg_hue, 0.9, 0.957),
-                    Hsv::new(fg_hue, 0.9, 0.5),
-                ),
-                (
-                    2046u16,
-                    Hsv::new(bg_hue, 0.99, 0.957),
-                    Hsv::new(fg_hue, 0.9, 0.5),
-                ),
-            ]
-            .into_iter()
-            .map(|(k, bg_hsv, fg_hsv)| {
-                (k, (Srgb::from_color(bg_hsv).into_format::<u8>(), Srgb::from_color(fg_hsv).into_format::<u8>()))
-            })
-            .map(|(k, (bg_rgb, fg_rgb))| {
-                (
-                    k,
+            (0..11)
+                .into_iter()
+                .map(|i| {
                     (
-                        Modifier::BackgroundColor(bg_rgb.red, bg_rgb.green, bg_rgb.blue),
-                        Modifier::ForegroundColor(fg_rgb.red, fg_rgb.green, fg_rgb.blue),
-                    ),
-                )
-            }),
+                        2u16.pow(i),
+                        Lch::new(80.0, 90.0, i as f32 * 360.0/10.0),
+                        Lch::new(20.0, 50.0, fg_hue),
+                    )
+                })
+                .map(|(k, bg_hsv, fg_hsv)| {
+                    (
+                        k,
+                        (
+                            Srgb::from_color(bg_hsv).into_format::<u8>(),
+                            Srgb::from_color(fg_hsv).into_format::<u8>(),
+                        ),
+                    )
+                })
+                .map(|(k, (bg_rgb, fg_rgb))| {
+                    (
+                        k,
+                        (
+                            Modifier::BackgroundColor(bg_rgb.red, bg_rgb.green, bg_rgb.blue),
+                            Modifier::ForegroundColor(fg_rgb.red, fg_rgb.green, fg_rgb.blue),
+                        ),
+                    )
+                }),
         ),
     };
     DEFAULT_COLORS

--- a/src/tui48.rs
+++ b/src/tui48.rs
@@ -263,7 +263,8 @@ impl Tui48Board {
             let idx = slot.idx()?;
             self.put_slot(&idx, slot)?;
         }
-        self.moving_slots = Vec::new();
+
+        let _ = self.moving_slots.drain(0..);
 
         Ok(())
     }

--- a/src/tui48.rs
+++ b/src/tui48.rs
@@ -622,7 +622,7 @@ impl<R: Renderer, E: EventSource> Tui48<R, E> {
                     .expect("why wouldn't we have a tui board at this point?");
                 tui_board.setup_animation(hint)?;
                 while tui_board.animate()? {
-                    std::thread::sleep(std::time::Duration::from_millis(50));
+                    std::thread::sleep(std::time::Duration::from_millis(1));
                     self.renderer.render(&self.canvas)?;
                 }
                 tui_board.teardown_animation()?;

--- a/src/tui48.rs
+++ b/src/tui48.rs
@@ -954,7 +954,7 @@ mod test {
             for y in 0..3 {
                 let idx = BoardIdx(x, y);
                 if let Some(v) = idxs.get(&idx) {
-                    round._set_value(&idx, v.clone());
+                    round.set_value(&idx, v.clone());
                 }
             }
         }
@@ -970,7 +970,7 @@ mod test {
         let rng = rand::rngs::SmallRng::seed_from_u64(10);
         let mut game_board = Board::new(rng);
         let round = generate_round_from(idxs);
-        game_board._set_initial_round(round);
+        game_board.set_initial_round(round);
 
         let tui_board = Tui48Board::new(&game_board, &mut canvas)?;
         Ok((game_board, canvas, tui_board))

--- a/src/tui48.rs
+++ b/src/tui48.rs
@@ -73,7 +73,7 @@ const UPPER_ANIMATION_LAYER_IDX: usize = 5;
 impl Tui48Board {
     fn new(game: &Board, canvas: &mut Canvas) -> Result<Self> {
         let board_rectangle = Rectangle(
-            Idx(BOARD_FIXED_X_OFFSET, BOARD_FIXED_Y_OFFSET, 0),
+            Idx(BOARD_FIXED_X_OFFSET, BOARD_FIXED_Y_OFFSET, BOARD_LAYER_IDX),
             Bounds2D(36, 25),
         );
         let (cwidth, cheight) = canvas.dimensions();
@@ -85,7 +85,8 @@ impl Tui48Board {
         let mut board = canvas.get_draw_buffer(board_rectangle)?;
         board.draw_border()?;
 
-        let mut score = canvas.get_draw_buffer(Rectangle(Idx(18, 1, 0), Bounds2D(10, 3)))?;
+        let mut score =
+            canvas.get_draw_buffer(Rectangle(Idx(18, 1, BOARD_LAYER_IDX), Bounds2D(10, 3)))?;
         score.draw_border()?;
         score.fill(' ')?;
         score.write_right(&format!("{}", game.score()))?;
@@ -105,14 +106,9 @@ impl Tui48Board {
                 let mut opt = None;
                 let value = round.get(&BoardIdx(x, y));
                 if value > 0 {
-                    let r = Self::tile_rectangle(x, y, 5);
+                    let r = Self::tile_rectangle(x, y, TILE_LAYER_IDX);
                     let mut card_buffer = canvas.get_draw_buffer(r)?;
-                    let colors = colors_from_value(value);
-                    card_buffer.modify(colors.0);
-                    card_buffer.modify(colors.1);
-                    card_buffer.draw_border()?;
-                    card_buffer.fill(' ')?;
-                    card_buffer.write_center(&format!("{}", value))?;
+                    Tui48Board::draw_tile(&mut card_buffer, value)?;
                     opt = Some(card_buffer);
                 }
                 row.push(opt);
@@ -142,6 +138,16 @@ impl Tui48Board {
         );
         let bounds = Bounds2D(TILE_WIDTH, TILE_HEIGHT);
         Rectangle(idx, bounds)
+    }
+
+    fn draw_tile(dbuf: &mut DrawBuffer, value: u16) -> Result<()> {
+        let colors = colors_from_value(value);
+        dbuf.modify(colors.0);
+        dbuf.modify(colors.1);
+        dbuf.draw_border()?;
+        dbuf.fill(' ')?;
+        dbuf.write_center(&format!("{}", value))?;
+        Ok(())
     }
 }
 

--- a/src/tui48.rs
+++ b/src/tui48.rs
@@ -298,10 +298,18 @@ impl Slot {
 
     fn to_sliding(this: Self, to_idx: BoardIdx, new_value: Option<u16>) -> Result<Self> {
         // only allow static tiles to be converted to sliding
-        let t = match this {
+        let mut t = match this {
             Self::Static(t) => t,
-            Self::Empty => return Err(Error::CannotConvertToSliding),
-            Self::Sliding(_) => return Err(Error::CannotConvertToSliding),
+            Self::Empty => {
+                return Err(Error::CannotConvertToSliding {
+                    idx: to_idx.clone(),
+                })
+            }
+            Self::Sliding(_) => {
+                return Err(Error::CannotConvertToSliding {
+                    idx: to_idx.clone(),
+                })
+            }
         };
 
         t.buf.switch_layer(UPPER_ANIMATION_LAYER_IDX)?;

--- a/src/tui48.rs
+++ b/src/tui48.rs
@@ -190,20 +190,20 @@ impl Tui48Board {
     ) -> Result<SlidingTile> {
         let db_rectangle = match direction {
             Direction::Left => {
-                let r = Tui48Board::tile_rectangle(4, to_idx.y(), UPPER_ANIMATION_LAYER_IDX);
+                let r = Tui48Board::tile_rectangle(4, to_idx.y(), LOWER_ANIMATION_LAYER_IDX);
                 r
             }
             Direction::Right => {
-                let mut r = Tui48Board::tile_rectangle(0, to_idx.y(), UPPER_ANIMATION_LAYER_IDX);
+                let mut r = Tui48Board::tile_rectangle(0, to_idx.y(), LOWER_ANIMATION_LAYER_IDX);
                 r.0 .0 -= 6;
                 r
             }
             Direction::Up => {
-                let r = Tui48Board::tile_rectangle(to_idx.x(), 4, UPPER_ANIMATION_LAYER_IDX);
+                let r = Tui48Board::tile_rectangle(to_idx.x(), 4, LOWER_ANIMATION_LAYER_IDX);
                 r
             }
             Direction::Down => {
-                let mut r = Tui48Board::tile_rectangle(to_idx.x(), 0, UPPER_ANIMATION_LAYER_IDX);
+                let mut r = Tui48Board::tile_rectangle(to_idx.x(), 0, LOWER_ANIMATION_LAYER_IDX);
                 r.0 .1 -= 6;
                 r
             }
@@ -313,8 +313,13 @@ impl Slot {
         };
 
         t.buf.switch_layer(UPPER_ANIMATION_LAYER_IDX)?;
-        let rectangle = Tui48Board::tile_rectangle(to_idx.0, to_idx.1, UPPER_ANIMATION_LAYER_IDX);
-        let st = SlidingTile::new(t, rectangle);
+        if let Some(v) = new_value {
+            Tui48Board::draw_tile(&mut t.buf, v)?;
+        } else {
+            Tui48Board::draw_tile(&mut t.buf, 5)?;
+        }
+        let to_rectangle = Tui48Board::tile_rectangle(to_idx.0, to_idx.1, UPPER_ANIMATION_LAYER_IDX);
+        let st = SlidingTile::new(t, to_rectangle);
 
         Ok(Slot::Sliding(st))
     }

--- a/src/tui48.rs
+++ b/src/tui48.rs
@@ -67,14 +67,15 @@ impl Tui48Board {
 
         let mut board = canvas.get_draw_buffer(board_rectangle)?;
         board.draw_border()?;
-        board.fill(' ')?;
 
         let mut score = canvas.get_draw_buffer(Rectangle(Idx(18, 1, 0), Bounds2D(10, 3)))?;
         score.draw_border()?;
         score.fill(' ')?;
         score.write_right(&format!("{}", game.score()))?;
-        score.modify(Modifier::BackgroundColor(255, 255, 255));
-        score.modify(Modifier::ForegroundColor(0, 0, 0));
+        score.modify(Modifier::SetBackgroundColor(75, 50, 25));
+        score.modify(Modifier::SetForegroundColor(0, 0, 0));
+        score.modify(Modifier::SetFGLightness(0.2));
+        score.modify(Modifier::SetBGLightness(0.8));
 
         let (width, height) = game.dimensions();
         let round = game.current();
@@ -90,13 +91,11 @@ impl Tui48Board {
                     let idx = Idx(x_offset + (2 + 6) * x, y_offset + (1 + 5) * y, 5);
                     let bounds = Bounds2D(6, 5);
                     let mut card_buffer = canvas.get_draw_buffer(Rectangle(idx, bounds))?;
-                    card_buffer.modify(Modifier::Bold);
                     let colors = colors_from_value(value);
                     card_buffer.modify(colors.0);
                     card_buffer.modify(colors.1);
                     card_buffer.draw_border()?;
                     card_buffer.fill(' ')?;
-                    card_buffer.modify(Modifier::Bold);
                     card_buffer.write_center(&format!("{}", value))?;
                     opt = Some(card_buffer);
                 }
@@ -104,6 +103,12 @@ impl Tui48Board {
             }
             slots.push(row);
         }
+
+        board.fill(' ')?;
+        board.modify(Modifier::SetBackgroundColor(40, 0, 0));
+        board.modify(Modifier::SetBGLightness(0.2));
+        board.modify(Modifier::SetForegroundColor(25, 50, 75));
+        board.modify(Modifier::SetFGLightness(0.6));
         Ok(Self {
             _board: board,
             _score: score,
@@ -178,6 +183,7 @@ impl AnimatedTui48Board {
 }
 
 struct Colors {
+    // TODO: change this from canvas::Modifer to colors::Rgb
     card_colors: HashMap<u16, (Modifier, Modifier)>,
 }
 
@@ -193,25 +199,23 @@ pub(crate) fn init() -> Result<()> {
                 .map(|i| {
                     (
                         2u16.pow(i),
-                        Lch::new(80.0, 90.0, i as f32 * 360.0/10.0),
+                        Lch::new(80.0, 90.0, i as f32 * 360.0 / 10.0),
                         Lch::new(20.0, 50.0, fg_hue),
                     )
                 })
                 .map(|(k, bg_hsv, fg_hsv)| {
                     (
                         k,
-                        (
-                            Srgb::from_color(bg_hsv).into_format::<u8>(),
-                            Srgb::from_color(fg_hsv).into_format::<u8>(),
-                        ),
+                        Srgb::from_color(bg_hsv).into_format::<u8>(),
+                        Srgb::from_color(fg_hsv).into_format::<u8>(),
                     )
                 })
-                .map(|(k, (bg_rgb, fg_rgb))| {
+                .map(|(k, bg_rgb, fg_rgb)| {
                     (
                         k,
                         (
-                            Modifier::BackgroundColor(bg_rgb.red, bg_rgb.green, bg_rgb.blue),
-                            Modifier::ForegroundColor(fg_rgb.red, fg_rgb.green, fg_rgb.blue),
+                            Modifier::SetBackgroundColor(bg_rgb.red, bg_rgb.green, bg_rgb.blue),
+                            Modifier::SetForegroundColor(fg_rgb.red, fg_rgb.green, fg_rgb.blue),
                         ),
                     )
                 }),
@@ -231,8 +235,8 @@ fn colors_from_value(value: u16) -> (Modifier, Modifier) {
         .card_colors
         .get(&value)
         .unwrap_or(&(
-            Modifier::BackgroundColor(255, 255, 255),
-            Modifier::ForegroundColor(90, 0, 0),
+            Modifier::SetBackgroundColor(255, 255, 255),
+            Modifier::SetForegroundColor(90, 0, 0),
         ));
     (background.clone(), foreground.clone())
 }

--- a/src/tui48.rs
+++ b/src/tui48.rs
@@ -184,7 +184,6 @@ impl AnimatedTui48Board {
                 Hint::NewValueToIdx(new_value, to_idx) => {
                     let should_continue =
                         self.animate_shifting_tile(Some(new_value), &idx, &to_idx)?;
-                    //self.animate_displaced_tile(to_idx, should_continue)?;
                     if !should_continue {
                         self.animation_hint.remove(&idx, &hint);
                     }
@@ -192,7 +191,6 @@ impl AnimatedTui48Board {
                 }
                 Hint::ToIdx(to_idx) => {
                     let should_continue = self.animate_shifting_tile(None, &idx, &to_idx)?;
-                    //self.animate_displaced_tile(to_idx.clone(), should_continue)?;
                     if !should_continue {
                         self.animation_hint.remove(&idx, &hint);
                     }
@@ -209,39 +207,6 @@ impl AnimatedTui48Board {
             }
         }
         Ok(continue_animation)
-    }
-
-    fn animate_displaced_tile(&mut self, displace_idx: &BoardIdx, last_frame: bool) -> Result<()> {
-        if last_frame {
-            // on the last frame, drop the animation buffer
-            self.displace_tile = None;
-            return Ok(());
-        }
-
-        let displace_buf = match self.tui_board.slots[displace_idx.y()][displace_idx.x()].take() {
-            Some(db) => db,
-            None => return Ok(()),
-        };
-        let displace_tile = match &self.displace_tile {
-            None => {
-                // copy buffer to bottom layer as self.displace_tile
-                let dbuf = Rc::new(RefCell::new(
-                    displace_buf.clone_to(LOWER_ANIMATION_LAYER_IDX)?,
-                ));
-                // drop old buffer, should trigger clear of buffer and return of tuxels to the
-                // canvas
-                drop(displace_buf);
-                self.displace_tile = Some(dbuf.clone());
-                dbuf
-            }
-            Some(dbuf) => dbuf.clone(),
-        };
-
-        let mut displace_tile = displace_tile.borrow_mut();
-        displace_tile.modify(Modifier::AdjustLightnessBG(-0.1));
-        displace_tile.modify(Modifier::AdjustLightnessFG(-0.1));
-
-        Ok(())
     }
 
     fn animate_shifting_tile(

--- a/src/tui48.rs
+++ b/src/tui48.rs
@@ -920,7 +920,7 @@ impl<R: Renderer, E: EventSource> Tui48<R, E> {
             let mut fc = 0;
             while tui_board.animate()? {
                 log::trace!("generated animation frame {0}\n{1}", fc, tui_board);
-                std::thread::sleep(std::time::Duration::from_millis(1));
+                std::thread::sleep(std::time::Duration::from_millis(5));
                 self.renderer.render(&self.canvas)?;
                 log::trace!("rendered frame {} after sleeping 1ms", fc);
 

--- a/src/tui48.rs
+++ b/src/tui48.rs
@@ -233,7 +233,7 @@ impl Tui48Board {
                 }
                 Hint::NewTile(value, slide_direction) => {
                     let t = self.new_sliding_tile(&idx, value, &slide_direction)?;
-                    let _ = slot.replace(Slot::Sliding(t));
+                    slot = Slot::Sliding(t);
                 }
             }
             self.put_slot(&idx, slot)?;

--- a/src/tui48.rs
+++ b/src/tui48.rs
@@ -188,13 +188,26 @@ impl Tui48Board {
         value: u16,
         direction: &Direction,
     ) -> Result<SlidingTile> {
-        let (x, y, z) = match direction {
-            Direction::Left => (0, 0, 0),
-            Direction::Right => (0, 0, 0),
-            Direction::Up => (0, 0, 0),
-            Direction::Down => (0, 0, 0),
+        let db_rectangle = match direction {
+            Direction::Left => {
+                let r = Tui48Board::tile_rectangle(4, to_idx.y(), UPPER_ANIMATION_LAYER_IDX);
+                r
+            }
+            Direction::Right => {
+                let mut r = Tui48Board::tile_rectangle(0, to_idx.y(), UPPER_ANIMATION_LAYER_IDX);
+                r.0 .0 -= 6;
+                r
+            }
+            Direction::Up => {
+                let r = Tui48Board::tile_rectangle(to_idx.x(), 4, UPPER_ANIMATION_LAYER_IDX);
+                r
+            }
+            Direction::Down => {
+                let mut r = Tui48Board::tile_rectangle(to_idx.x(), 0, UPPER_ANIMATION_LAYER_IDX);
+                r.0 .1 -= 6;
+                r
+            }
         };
-        let db_rectangle = Tui48Board::tile_rectangle(x, y, z);
         let mut buf = self.canvas.get_draw_buffer(db_rectangle)?;
         Tui48Board::draw_tile(&mut buf, value)?;
         let t = Tile {


### PR DESCRIPTION
This is a big set of changes with high level goals of creating an animated
tui48 board, but which also includes a hefty amount of refactoring and
debugging/logging oriented additions.

# general
* introduce logging and `impl Display` or `impl Debug` for several key types
* add various test cases to reproduce bugs

# engine (game logic)
* minor `AnimationHint` refactor 
* add new type of `AnimationHint` to tell tui48 code where new tiles should be
  placed and from what direction.

# tui48 (engine + tui framework)
* generate a card color palette programatically using `palette` crate
* add animation code/logic
  * no longer redraw entire board on every frame, only redraw changed tuxels

# tui

## tuxel
* eliminate `Modifier` and `SharedModifier` field members

## canvas
* wrap `Canvas` with `Arc<Mutex<_>>` so that each `DrawBuffer` can reference it
  as necessary during translational movement
* check bounds before creating new `DrawBuffer`, return `Err` if out of bounds
* refactor `Stack` grid to use `Cell` (kind of like an `Option<T>` but specific
  to `DBTuxel` to allow `Canvas`-based translational movement to detect
  conflicting `DrawBuffer` and return an error if appropriate

## drawbuffer
* implement basic translational movements through parent `Canvas`
  * between layers
  * left, right, up, down
* `impl Drop for DrawBuffer` -- clear tuxels and send them back to the `Canvas`
* introduce new `DBTuxel` that represents an individual `Tuxel` "owned" by a
  `DrawBuffer`

## geometry
* `impl IntoIter for Rectangle`
* implement various helper functions for calculating new `Rectangle`s given a
  desired direction/magnitude

## error
* capture backtrace when an error occurs

## crossterm
* try using synchronized update (eg rather than queuing every change manually)
