### PR TITLE
tui48: address feedback from manual tester

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,6 +12,55 @@ dependencies = [
 ]
 
 [[package]]
+name = "anstream"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ca84f3628370c59db74ee214b3263d58f9aadd9b4fe7e711fd87dc452b7f163"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is-terminal",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a30da5c5f2d5e72842e00bcb57657162cdabef0931f40e2deb9b4140440cecd"
+
+[[package]]
+name = "anstyle-parse"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "938874ff5980b03a87c5524b3ae5b59cf99b1d6bc836848df7bc5ada9643c333"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ca11d4be1bab0c8bc8734a9aa7bf4ee8316d462a08c6ac5052f888fef5b494b"
+dependencies = [
+ "windows-sys",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c677ab05e09154296dd37acecd46420c17b9713e8366facafa8fc0885167cf4c"
+dependencies = [
+ "anstyle",
+ "windows-sys",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -61,6 +110,63 @@ name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "clap"
+version = "4.3.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c27cdf28c0f604ba3f512b0c9a409f8de8513e4816705deb0498b627e7c3a3fd"
+dependencies = [
+ "clap_builder",
+ "clap_derive",
+ "once_cell",
+]
+
+[[package]]
+name = "clap-verbosity-flag"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1eef05769009513df2eb1c3b4613e7fad873a14c600ff025b08f250f59fee7de"
+dependencies = [
+ "clap",
+ "log",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.3.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08a9f1ab5e9f01a9b81f202e8562eb9a10de70abf9eaeac1be465c28b75aa4aa"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "clap_lex",
+ "strsim",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.3.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54a9bb5758fc5dfe728d1019941681eccaf0cf8a4189b692a0ee2f2ecf90a050"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.23",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2da6da31387c7e4ef160ffab6d5e7f00c42626fe39aea70a7b0f1773f7dd6c1b"
+
+[[package]]
+name = "colorchoice"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
 
 [[package]]
 name = "crossterm"
@@ -243,6 +349,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "heck"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
+
+[[package]]
 name = "hermit-abi"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -319,6 +431,12 @@ checksum = "578ede34cf02f8924ab9447f50c28075b4d3e5b269972345e7e0372b38c6cdcd"
 dependencies = [
  "autocfg",
 ]
+
+[[package]]
+name = "once_cell"
+version = "1.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d"
 
 [[package]]
 name = "palette"
@@ -624,6 +742,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a507befe795404456341dfab10cef66ead4c041f62b8b11bbb92bffe5d0953e0"
 
 [[package]]
+name = "strsim"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
+
+[[package]]
 name = "syn"
 version = "1.0.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -680,6 +804,8 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "boxy",
+ "clap",
+ "clap-verbosity-flag",
  "crossterm",
  "env_logger",
  "fern",
@@ -695,6 +821,12 @@ name = "unicode-ident"
 version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22049a19f4a68748a168c0fc439f9516686aa045927ff767eca0a85101fb6e73"
+
+[[package]]
+name = "utf8parse"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
 
 [[package]]
 name = "wasi"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -742,6 +742,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a507befe795404456341dfab10cef66ead4c041f62b8b11bbb92bffe5d0953e0"
 
 [[package]]
+name = "smawk"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f67ad224767faa3c7d8b6d91985b78e70a1324408abcb1cfcc2be4c06bc06043"
+
+[[package]]
 name = "strsim"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -779,6 +785,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "textwrap"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "222a222a5bfe1bba4a77b45ec488a741b3cb8872e5e499451fd7d0129c9c7c3d"
+dependencies = [
+ "smawk",
+ "unicode-linebreak",
+ "unicode-width",
+]
+
+[[package]]
 name = "thiserror"
 version = "1.0.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -813,6 +830,7 @@ dependencies = [
  "palette",
  "rand",
  "rstest",
+ "textwrap",
  "thiserror",
 ]
 
@@ -821,6 +839,18 @@ name = "unicode-ident"
 version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22049a19f4a68748a168c0fc439f9516686aa045927ff767eca0a85101fb6e73"
+
+[[package]]
+name = "unicode-linebreak"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b09c83c3c29d37506a3e260c08c03743a6bb66a9cd432c6934ab501a190571f"
+
+[[package]]
+name = "unicode-width"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0edd1e5b14653f783770bce4a4dabb4a5108a5370a5f5d8cfe8710c361f6c8b"
 
 [[package]]
 name = "utf8parse"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ clap-verbosity-flag = "2.0"
 # drawing & colors
 boxy = "0.1"
 palette = "0.7"
+textwrap = { version = "0.16", features = ["smawk"] }
 
 # rendering
 crossterm = "0.26"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,15 +12,25 @@ strip = true
 
 [dependencies]
 
-crossterm = "0.26"
-boxy = "0.1"
-rand = "0.8.5"
+# error handling
 thiserror = "1.0"
 anyhow = "1.0"
+
+# logging & cli
 log = "0.4"
 fern = "0.6"
+clap = { version = "4.3", features = ["derive"] }
+clap-verbosity-flag = "2.0"
 
+# drawing & colors
+boxy = "0.1"
 palette = "0.7"
+
+# rendering
+crossterm = "0.26"
+
+# misc
+rand = "0.8.5"
 
 [dev-dependencies]
 

--- a/README.md
+++ b/README.md
@@ -24,11 +24,15 @@ cd tui48
 cargo install --path ./
 ```
 
+**Note**: this approach assumes you have the [cargo install] target directory
+included in your shell's `PATH` variable.  If you don't then instead of running
+`tui48` in your path, you will have to run `<PATH_TO_TUI48>/target/debug/tui48`
+
 ## Running
 
-Once installed, try running it in your favorite terminal emulator!. I recommend
-[alacritty], which what I prefer for my every day terminal usage and is the
-only terminal emulator I've tested it on.
+Once installed, try running `tui48` in your favorite terminal emulator!. I
+recommend [alacritty], which what I prefer for my every day terminal usage and
+is the only terminal emulator I've tested it on. Here's how to do it:
 
 If you do use a different terminal emulator, please let me know and report any
 bugs on this git repo's issue tracker!
@@ -70,4 +74,4 @@ will allow the player to continue as far as they can to produce higher values
 [terminal emulator]: https://en.wikipedia.org/wiki/Terminal_emulator
 [using rustup]: https://rustup.rs/
 [alacritty]: https://github.com/alacritty/alacritty
-
+[cargo install]: https://doc.rust-lang.org/cargo/commands/cargo-install.html

--- a/src/engine/board.rs
+++ b/src/engine/board.rs
@@ -51,6 +51,13 @@ impl Board {
         (4, 4)
     }
 
+    pub(crate) fn is_game_over(&self) -> bool {
+        self.rounds
+            .last()
+            .expect("a board must always have at least one round")
+            .is_game_over(&Direction::Right)
+    }
+
     #[cfg(test)]
     pub(crate) fn set_initial_round(&mut self, round: Round) {
         let mut v = Vec::with_capacity(1);

--- a/src/engine/round.rs
+++ b/src/engine/round.rs
@@ -141,7 +141,7 @@ impl Round {
 
     pub fn shift<T: Rng>(&mut self, mut rng: T, direction: &Direction) -> Option<AnimationHint> {
         let mut hint = AnimationHint::new();
-        let idxs = self.iter_mut(direction).collect::<Vec<Idx>>();
+        let idxs = self.indices(direction).collect::<Vec<Idx>>();
         let rows = idxs.chunks(4);
         for row in rows {
             let mut pivot_iter = row.iter();
@@ -199,7 +199,7 @@ impl Round {
 
 // private methods
 impl Round {
-    fn iter_mut(&self, direction: &Direction) -> Indices {
+    fn indices(&self, direction: &Direction) -> Indices {
         Indices::new(self, direction.clone())
     }
 
@@ -217,7 +217,7 @@ impl Round {
     }
 
     fn is_game_over(&self, direction_hint: &Direction) -> bool {
-        self.iter_mut(direction_hint).find(|v| self.get(&v) == 0).is_none()
+        self.indices(direction_hint).find(|v| self.get(&v) == 0).is_none()
     }
 
     #[cfg(test)]

--- a/src/engine/round.rs
+++ b/src/engine/round.rs
@@ -81,6 +81,10 @@ impl AnimationHint {
     pub(crate) fn hints(&self) -> Vec<(Idx, Hint)> {
         self.hint.clone()
     }
+
+    pub(crate) fn game_over(&self) -> bool {
+        self.game_over
+    }
 }
 
 pub(crate) type Card = u16;

--- a/src/engine/round.rs
+++ b/src/engine/round.rs
@@ -199,6 +199,11 @@ impl Round {
             None
         }
     }
+
+    pub(crate) fn is_game_over(&self, direction_hint: &Direction) -> bool {
+        self.indices(direction_hint).find(|v| self.get(&v) == 0).is_none()
+    }
+
 }
 
 // private methods
@@ -218,10 +223,6 @@ impl Round {
     fn set(&mut self, idx: &Idx, value: Card) {
         let rf = self.get_mut(idx);
         *rf = value;
-    }
-
-    fn is_game_over(&self, direction_hint: &Direction) -> bool {
-        self.indices(direction_hint).find(|v| self.get(&v) == 0).is_none()
     }
 
     #[cfg(test)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,7 @@
 use std::io::stdout;
 
 use anyhow::Result;
+use clap::Parser;
 use rand::thread_rng;
 
 mod engine;
@@ -12,7 +13,15 @@ use engine::board::Board;
 use tui::crossterm::{Crossterm, CrosstermEvents};
 use tui48::{init, Tui48};
 
+#[derive(Debug, Parser)]
+struct Cli {
+    #[clap(flatten)]
+    verbose: clap_verbosity_flag::Verbosity,
+}
+
 fn main() -> Result<()> {
+    let cli = Cli::parse();
+
     let rng = thread_rng();
     let board = Board::new(rng);
     let w = stdout().lock();
@@ -28,21 +37,13 @@ fn main() -> Result<()> {
                 message,
             ))
         })
-        .level(log::LevelFilter::Trace)
+        .level(cli.verbose.log_level_filter())
         .chain(fern::log_file("./output.log")?)
         .apply()?;
-
-    log::info!("log test");
 
     init()?;
 
     tui48.run()?;
-    // match tui48.run() {
-    //     Err(e) => {
-    //         eprintln!("{}", e);
-    //     },
-    //     Ok(_) => eprintln!("everything okay!"),
-    // }
 
     Ok(())
 }

--- a/src/tui/canvas.rs
+++ b/src/tui/canvas.rs
@@ -209,7 +209,7 @@ impl Canvas {
             grid.push(row);
         }
 
-        let (idx_sender, idx_receiver) = sync_channel(width*height*20);
+        let (idx_sender, idx_receiver) = sync_channel(width * height * 20);
         let (tuxel_sender, tuxel_receiver) = channel();
         let c = Self {
             inner: Arc::new(Mutex::new(CanvasInner {
@@ -534,7 +534,7 @@ mod test {
     #[case::base((5, 5))]
     #[case::realistic((274, 75))]
     fn get_layer_validate_draw_buffer_size(#[case] dims: (usize, usize)) -> Result<()> {
-        let canvas = Canvas::new(dims.0, dims.1);
+        let mut canvas = Canvas::new(dims.0, dims.1);
         let dbuf = canvas.get_layer(0)?;
         let inner = dbuf.lock();
         assert_eq!(inner.buf.len(), dims.1);

--- a/src/tui/canvas.rs
+++ b/src/tui/canvas.rs
@@ -50,15 +50,6 @@ impl CanvasInner {
         self.get_draw_buffer(c, Rectangle(Idx(0, 0, z), self.rectangle.1.clone()))
     }
 
-    fn draw_all(&mut self) -> Result<()> {
-        for row in self.grid.iter_mut() {
-            for stack in row.iter_mut() {
-                self.idx_sender.send(stack.lock().idx.clone())?
-            }
-        }
-        Ok(())
-    }
-
     fn dimensions(&self) -> (usize, usize) {
         (self.rectangle.1 .0, self.rectangle.1 .1)
     }
@@ -277,10 +268,6 @@ impl Canvas {
     pub(crate) fn get_layer(&self, z: usize) -> Result<DrawBuffer> {
         let c = self.clone();
         self.lock().get_layer(c, z)
-    }
-
-    fn draw_all(&mut self) -> Result<()> {
-        self.lock().draw_all()
     }
 
     pub(crate) fn bounds(&self) -> Bounds2D {

--- a/src/tui/canvas.rs
+++ b/src/tui/canvas.rs
@@ -3,6 +3,7 @@ use std::sync::{Arc, Mutex, MutexGuard};
 
 use super::colors::Rgb;
 use super::drawbuffer::{DBTuxel, DrawBuffer, DrawBufferOwner};
+use super::textbuffer::TextBuffer;
 use super::error::{InnerError, Result, TuiError};
 use super::geometry::{Bounds2D, Geometry, Idx, Rectangle};
 use super::tuxel::Tuxel;
@@ -238,6 +239,18 @@ impl Canvas {
             inner.reclaim();
             inner.rectangle.contains_or_err(Geometry::Rectangle(&r))?;
             DrawBuffer::new(inner.tuxel_sender.clone(), r.clone(), c)
+        };
+        self.populate_drawbuffer(&mut dbuf)?;
+        Ok(dbuf)
+    }
+
+    pub(crate) fn get_text_buffer(&self, r: Rectangle) -> Result<TextBuffer> {
+        let c = self.clone();
+        let mut dbuf = {
+            let mut inner = self.lock();
+            inner.reclaim();
+            inner.rectangle.contains_or_err(Geometry::Rectangle(&r))?;
+            TextBuffer::new(inner.tuxel_sender.clone(), r.clone(), c)
         };
         self.populate_drawbuffer(&mut dbuf)?;
         Ok(dbuf)

--- a/src/tui/crossterm.rs
+++ b/src/tui/crossterm.rs
@@ -149,6 +149,7 @@ fn handle_key_event(ke: KeyEvent) -> Option<UserInput> {
             KeyCode::Up | KeyCode::Char('k') => Some(UserInput::Direction(Direction::Up)),
             KeyCode::Down | KeyCode::Char('j') => Some(UserInput::Direction(Direction::Down)),
             KeyCode::Char('q') => Some(UserInput::Quit),
+            KeyCode::Char('n') => Some(UserInput::NewGame),
             _ => None,
         },
     }

--- a/src/tui/drawbuffer.rs
+++ b/src/tui/drawbuffer.rs
@@ -124,8 +124,7 @@ impl DrawBufferInner {
     }
 
     #[inline(always)]
-    pub (crate) fn get_tuxel_mut(&mut self, pos: Position) -> Result<&mut Tuxel> {
-
+    pub(crate) fn get_tuxel_mut(&mut self, pos: Position) -> Result<&mut Tuxel> {
         let (x, y) = self.rectangle.relative_idx(&pos);
         let t = self
             .buf
@@ -137,7 +136,7 @@ impl DrawBufferInner {
     }
 
     #[inline(always)]
-    fn get_tuxel(&self, pos: Position) -> Result<&Tuxel> {
+    pub(crate) fn get_tuxel(&self, pos: Position) -> Result<&Tuxel> {
         let (x, y) = self.rectangle.relative_idx(&pos);
         let t = self
             .buf

--- a/src/tui/drawbuffer.rs
+++ b/src/tui/drawbuffer.rs
@@ -124,7 +124,7 @@ impl DrawBufferInner {
     }
 
     #[inline(always)]
-    fn get_tuxel_mut(&mut self, pos: Position) -> Result<&mut Tuxel> {
+    pub (crate) fn get_tuxel_mut(&mut self, pos: Position) -> Result<&mut Tuxel> {
 
         let (x, y) = self.rectangle.relative_idx(&pos);
         let t = self

--- a/src/tui/drawbuffer.rs
+++ b/src/tui/drawbuffer.rs
@@ -7,6 +7,47 @@ use super::error::{InnerError, Result};
 use super::geometry::{Direction, Idx, Position, Rectangle};
 use super::tuxel::Tuxel;
 
+pub(crate) trait DrawBufferOwner {
+    fn lock<'a>(&'a self) -> MutexGuard<'a, DrawBufferInner>;
+    fn inner(&self) -> Arc<Mutex<DrawBufferInner>>;
+
+    fn modify(&mut self, modifier: Modifier) {
+        self.lock().modifiers.push(modifier)
+    }
+
+    fn draw_border(&mut self) -> Result<()> {
+        self.lock().draw_border()
+    }
+
+    fn fill(&mut self, c: char) -> Result<()> {
+        self.lock().fill(c)
+    }
+
+    fn write_left(&mut self, s: &str) -> Result<()> {
+        self.lock().write_left(s)
+    }
+
+    fn write_right(&mut self, s: &str) -> Result<()> {
+        self.lock().write_right(s)
+    }
+
+    fn write_center(&mut self, s: &str) -> Result<()> {
+        self.lock().write_center(s)
+    }
+
+    fn translate(&self, dir: Direction) -> Result<()> {
+        self.lock().translate(dir)
+    }
+
+    fn switch_layer(&self, zdx: usize) -> Result<()> {
+        self.lock().switch_layer(zdx)
+    }
+
+    fn rectangle(&self) -> Rectangle {
+        self.lock().rectangle()
+    }
+}
+
 pub(crate) struct DrawBufferInner {
     pub(crate) rectangle: Rectangle,
     pub(crate) border: bool,
@@ -307,47 +348,6 @@ impl DrawBufferInner {
 
     fn tuxel_content(&self, x: usize, y: usize) -> Result<char> {
         Ok(self.get_tuxel(Position::Coordinates(x, y))?.content())
-    }
-}
-
-pub(crate) trait DrawBufferOwner {
-    fn lock<'a>(&'a self) -> MutexGuard<'a, DrawBufferInner>;
-    fn inner(&self) -> Arc<Mutex<DrawBufferInner>>;
-
-    fn modify(&mut self, modifier: Modifier) {
-        self.lock().modifiers.push(modifier)
-    }
-
-    fn draw_border(&mut self) -> Result<()> {
-        self.lock().draw_border()
-    }
-
-    fn fill(&mut self, c: char) -> Result<()> {
-        self.lock().fill(c)
-    }
-
-    fn write_left(&mut self, s: &str) -> Result<()> {
-        self.lock().write_left(s)
-    }
-
-    fn write_right(&mut self, s: &str) -> Result<()> {
-        self.lock().write_right(s)
-    }
-
-    fn write_center(&mut self, s: &str) -> Result<()> {
-        self.lock().write_center(s)
-    }
-
-    fn translate(&self, dir: Direction) -> Result<()> {
-        self.lock().translate(dir)
-    }
-
-    fn switch_layer(&self, zdx: usize) -> Result<()> {
-        self.lock().switch_layer(zdx)
-    }
-
-    fn rectangle(&self) -> Rectangle {
-        self.lock().rectangle()
     }
 }
 

--- a/src/tui/drawbuffer.rs
+++ b/src/tui/drawbuffer.rs
@@ -23,18 +23,6 @@ pub(crate) trait DrawBufferOwner {
         self.lock().fill(c)
     }
 
-    fn write_left(&mut self, s: &str) -> Result<()> {
-        self.lock().write_left(s)
-    }
-
-    fn write_right(&mut self, s: &str) -> Result<()> {
-        self.lock().write_right(s)
-    }
-
-    fn write_center(&mut self, s: &str) -> Result<()> {
-        self.lock().write_center(s)
-    }
-
     fn translate(&self, dir: Direction) -> Result<()> {
         self.lock().translate(dir)
     }
@@ -70,59 +58,6 @@ impl std::fmt::Display for DrawBufferInner {
 }
 
 impl DrawBufferInner {
-    fn write_left(&mut self, s: &str) -> Result<()> {
-        let y = self.rectangle.height() / 2;
-        let x = if self.border { 1 } else { 0 };
-        for (offset, c) in s.chars().enumerate() {
-            if offset > self.rectangle.width() + x {
-                // can't write more than width of buffer
-                break;
-            }
-            self.get_tuxel_mut(Position::Coordinates(offset + x, y))?
-                .set_content(c);
-        }
-        Ok(())
-    }
-
-    fn write_right(&mut self, s: &str) -> Result<()> {
-        let y = self.rectangle.height() / 2;
-        let x = if self.border {
-            self.rectangle.width() - 2
-        } else {
-            self.rectangle.width() - 1
-        };
-        for (offset, c) in s.chars().rev().enumerate() {
-            if offset > x + 1 {
-                // can't write more than width of buffer
-                break;
-            }
-            self.get_tuxel_mut(Position::Coordinates(x - offset, y))?
-                .set_content(c);
-        }
-        Ok(())
-    }
-
-    fn write_center(&mut self, s: &str) -> Result<()> {
-        let y_offset = self.rectangle.height() / 2;
-        let width = self.rectangle.width();
-        let available_width = if self.border { width - 2 } else { width };
-        let border_offset = if self.border { 1 } else { 0 };
-        let x_offset = if s.len() >= available_width {
-            border_offset
-        } else {
-            border_offset + ((available_width as f32 - s.len() as f32) / 2.0).ceil() as usize
-        };
-        for (idx, c) in s
-            .chars()
-            .enumerate()
-            .take_while(|(idx, _)| *idx < available_width)
-        {
-            self.get_tuxel_mut(Position::Coordinates(idx + x_offset, y_offset))?
-                .set_content(c);
-        }
-        Ok(())
-    }
-
     #[inline(always)]
     pub(crate) fn get_tuxel_mut(&mut self, pos: Position) -> Result<&mut Tuxel> {
         let (x, y) = self.rectangle.relative_idx(&pos);

--- a/src/tui/events.rs
+++ b/src/tui/events.rs
@@ -12,5 +12,6 @@ pub(crate) enum Event {
 
 pub(crate) enum UserInput {
     Direction(Direction),
+    NewGame,
     Quit,
 }

--- a/src/tui/geometry.rs
+++ b/src/tui/geometry.rs
@@ -151,6 +151,27 @@ impl Rectangle {
             }
         }
     }
+
+    #[inline(always)]
+    pub(crate) fn expand_by(&self, margin: usize) -> Rectangle {
+        let (x, width) = if self.0 .0 >= margin {
+            (self.0 .0 - margin, self.1 .0 + margin * 2)
+        } else if self.0 .0 == 0 {
+            (0, self.1 .0 + margin - self.0 .0 + margin)
+        } else {
+            (0, self.1 .0 + margin * 2)
+        };
+
+        let (y, height) = if self.0 .1 >= margin {
+            (self.0 .1 - margin, self.1 .1 + margin * 2)
+        } else if self.0 .1 == 0 {
+            (0, self.1 .1 + margin - self.0 .1 + margin)
+        } else {
+            (0, self.1 .1 + margin * 2)
+        };
+
+        Rectangle(Idx(x, y, self.0 .2), Bounds2D(width, height))
+    }
 }
 
 pub(crate) enum Geometry<'a> {
@@ -345,5 +366,39 @@ mod test {
         );
 
         Ok(())
+    }
+
+    #[rstest]
+    #[case::zero_rectangle_at_origin(rectangle(0, 0, 0, 0, 0), 0, rectangle(0, 0, 0, 0, 0))]
+    #[case::zero_rectangle_away_from_origin(
+        rectangle(10, 10, 0, 0, 0),
+        0,
+        rectangle(10, 10, 0, 0, 0)
+    )]
+    #[case::zero_at_origin_expand_by_1(rectangle(0, 0, 0, 0, 0), 1, rectangle(0, 0, 0, 2, 2))]
+    #[case::zero_at_origin_expand_by_5(rectangle(0, 0, 0, 0, 0), 5, rectangle(0, 0, 0, 10, 10))]
+    #[case::zero_away_from_origin_expand_by_1(
+        rectangle(10, 10, 0, 0, 0),
+        1,
+        rectangle(9, 9, 0, 2, 2)
+    )]
+    #[case::zero_away_from_origin_expand_by_5(
+        rectangle(10, 10, 0, 0, 0),
+        5,
+        rectangle(5, 5, 0, 10, 10)
+    )]
+    #[case::zero_near_origin_expand_by_5(rectangle(3, 3, 0, 0, 0), 5, rectangle(0, 0, 0, 10, 10))]
+    #[case::at_origin_expand_by_1(rectangle(0, 0, 0, 2, 2), 1, rectangle(0, 0, 0, 4, 4))]
+    #[case::at_origin_expand_by_5(rectangle(0, 0, 0, 2, 2), 5, rectangle(0, 0, 0, 12, 12))]
+    #[case::away_from_origin_expand_by_1(rectangle(10, 10, 0, 2, 2), 1, rectangle(9, 9, 0, 4, 4))]
+    #[case::away_from_origin_expand_by_5(rectangle(10, 10, 0, 2, 2), 5, rectangle(5, 5, 0, 12, 12))]
+    #[case::near_origin_expand_by_5(rectangle(3, 3, 0, 3, 3), 5, rectangle(0, 0, 0, 13, 13))]
+    fn validate_expand_by(
+        #[case] initial: Rectangle,
+        #[case] margin: usize,
+        #[case] expected: Rectangle,
+    ) {
+        let actual = initial.expand_by(margin);
+        assert_eq!(actual, expected);
     }
 }

--- a/src/tui/geometry.rs
+++ b/src/tui/geometry.rs
@@ -153,21 +153,21 @@ impl Rectangle {
     }
 
     #[inline(always)]
-    pub(crate) fn expand_by(&self, margin: usize) -> Rectangle {
-        let (x, width) = if self.0 .0 >= margin {
-            (self.0 .0 - margin, self.1 .0 + margin * 2)
+    pub(crate) fn expand_by(&self, x_margin: usize, y_margin: usize) -> Rectangle {
+        let (x, width) = if self.0 .0 >= x_margin {
+            (self.0 .0 - x_margin, self.1 .0 + x_margin * 2)
         } else if self.0 .0 == 0 {
-            (0, self.1 .0 + margin - self.0 .0 + margin)
+            (0, self.1 .0 + x_margin - self.0 .0 + x_margin)
         } else {
-            (0, self.1 .0 + margin * 2)
+            (0, self.1 .0 + x_margin * 2)
         };
 
-        let (y, height) = if self.0 .1 >= margin {
-            (self.0 .1 - margin, self.1 .1 + margin * 2)
+        let (y, height) = if self.0 .1 >= y_margin {
+            (self.0 .1 - y_margin, self.1 .1 + y_margin * 2)
         } else if self.0 .1 == 0 {
-            (0, self.1 .1 + margin - self.0 .1 + margin)
+            (0, self.1 .1 + y_margin - self.0 .1 + y_margin)
         } else {
-            (0, self.1 .1 + margin * 2)
+            (0, self.1 .1 + y_margin * 2)
         };
 
         Rectangle(Idx(x, y, self.0 .2), Bounds2D(width, height))
@@ -369,36 +369,36 @@ mod test {
     }
 
     #[rstest]
-    #[case::zero_rectangle_at_origin(rectangle(0, 0, 0, 0, 0), 0, rectangle(0, 0, 0, 0, 0))]
+    #[case::zero_rectangle_at_origin(rectangle(0, 0, 0, 0, 0), (0, 0), rectangle(0, 0, 0, 0, 0))]
     #[case::zero_rectangle_away_from_origin(
         rectangle(10, 10, 0, 0, 0),
-        0,
+        (0, 0),
         rectangle(10, 10, 0, 0, 0)
     )]
-    #[case::zero_at_origin_expand_by_1(rectangle(0, 0, 0, 0, 0), 1, rectangle(0, 0, 0, 2, 2))]
-    #[case::zero_at_origin_expand_by_5(rectangle(0, 0, 0, 0, 0), 5, rectangle(0, 0, 0, 10, 10))]
+    #[case::zero_at_origin_expand_by_1(rectangle(0, 0, 0, 0, 0), (1, 1), rectangle(0, 0, 0, 2, 2))]
+    #[case::zero_at_origin_expand_by_5(rectangle(0, 0, 0, 0, 0), (5, 5), rectangle(0, 0, 0, 10, 10))]
     #[case::zero_away_from_origin_expand_by_1(
         rectangle(10, 10, 0, 0, 0),
-        1,
+        (1, 1),
         rectangle(9, 9, 0, 2, 2)
     )]
     #[case::zero_away_from_origin_expand_by_5(
         rectangle(10, 10, 0, 0, 0),
-        5,
+        (5, 5),
         rectangle(5, 5, 0, 10, 10)
     )]
-    #[case::zero_near_origin_expand_by_5(rectangle(3, 3, 0, 0, 0), 5, rectangle(0, 0, 0, 10, 10))]
-    #[case::at_origin_expand_by_1(rectangle(0, 0, 0, 2, 2), 1, rectangle(0, 0, 0, 4, 4))]
-    #[case::at_origin_expand_by_5(rectangle(0, 0, 0, 2, 2), 5, rectangle(0, 0, 0, 12, 12))]
-    #[case::away_from_origin_expand_by_1(rectangle(10, 10, 0, 2, 2), 1, rectangle(9, 9, 0, 4, 4))]
-    #[case::away_from_origin_expand_by_5(rectangle(10, 10, 0, 2, 2), 5, rectangle(5, 5, 0, 12, 12))]
-    #[case::near_origin_expand_by_5(rectangle(3, 3, 0, 3, 3), 5, rectangle(0, 0, 0, 13, 13))]
+    #[case::zero_near_origin_expand_by_5(rectangle(3, 3, 0, 0, 0), (5, 5), rectangle(0, 0, 0, 10, 10))]
+    #[case::at_origin_expand_by_1(rectangle(0, 0, 0, 2, 2), (1, 1), rectangle(0, 0, 0, 4, 4))]
+    #[case::at_origin_expand_by_5(rectangle(0, 0, 0, 2, 2), (5, 5), rectangle(0, 0, 0, 12, 12))]
+    #[case::away_from_origin_expand_by_1(rectangle(10, 10, 0, 2, 2), (1, 1), rectangle(9, 9, 0, 4, 4))]
+    #[case::away_from_origin_expand_by_5(rectangle(10, 10, 0, 2, 2), (5, 5), rectangle(5, 5, 0, 12, 12))]
+    #[case::near_origin_expand_by_5(rectangle(3, 3, 0, 3, 3), (5, 5), rectangle(0, 0, 0, 13, 13))]
     fn validate_expand_by(
         #[case] initial: Rectangle,
-        #[case] margin: usize,
+        #[case] margin: (usize, usize),
         #[case] expected: Rectangle,
     ) {
-        let actual = initial.expand_by(margin);
+        let actual = initial.expand_by(margin.0, margin.1);
         assert_eq!(actual, expected);
     }
 }

--- a/src/tui/geometry.rs
+++ b/src/tui/geometry.rs
@@ -172,6 +172,23 @@ impl Rectangle {
 
         Rectangle(Idx(x, y, self.0 .2), Bounds2D(width, height))
     }
+
+    #[inline(always)]
+    pub(crate) fn shrink_by(&self, x_margin: usize, y_margin: usize) -> Rectangle {
+        let (x, width) = if self.1 .0 >= x_margin {
+            (self.0 .0 + x_margin, self.1 .0 - x_margin * 2)
+        } else {
+            (self.0 .0, 0)
+        };
+
+        let (y, height) = if self.1 .1 >= y_margin {
+            (self.0 .1 + y_margin, self.1 .1 - y_margin * 2)
+        } else {
+            (self.0 .1, 0)
+        };
+
+        Rectangle(Idx(x, y, self.0 .2), Bounds2D(width, height))
+    }
 }
 
 pub(crate) enum Geometry<'a> {
@@ -399,6 +416,36 @@ mod test {
         #[case] expected: Rectangle,
     ) {
         let actual = initial.expand_by(margin.0, margin.1);
+        assert_eq!(actual, expected);
+    }
+
+    #[rstest]
+    #[case::zero_rectangle_at_origin(rectangle(0, 0, 0, 0, 0), (0, 0), rectangle(0, 0, 0, 0, 0))]
+    #[case::zero_rectangle_away_from_origin(
+        rectangle(10, 10, 0, 0, 0),
+        (0, 0),
+        rectangle(10, 10, 0, 0, 0)
+    )]
+    #[case::zero_at_origin_shrink_by_1(rectangle(0, 0, 0, 0, 0), (1, 1), rectangle(0, 0, 0, 0, 0))]
+    #[case::zero_away_from_origin_shrink_by_1(
+        rectangle(10, 10, 0, 0, 0),
+        (1, 1),
+        rectangle(10, 10, 0, 0, 0)
+    )]
+    #[case::zero_near_origin_shrink_by_5(rectangle(3, 3, 0, 0, 0), (5, 5), rectangle(3, 3, 0, 0, 0))]
+    #[case::at_origin_shrink_2x2_by_1(rectangle(0, 0, 0, 2, 2), (1, 1), rectangle(1, 1, 0, 0, 0))]
+    #[case::at_origin_shrink_3x3_by_1(rectangle(0, 0, 0, 3, 3), (1, 1), rectangle(1, 1, 0, 1, 1))]
+    #[case::at_origin_shrink_20x20_by_5(rectangle(0, 0, 0, 20, 20), (5, 5), rectangle(5, 5, 0, 10, 10))]
+    #[case::away_from_origin_shrink_2x2_by_1(rectangle(10, 10, 0, 2, 2), (1, 1), rectangle(11, 11, 0, 0, 0))]
+    #[case::away_from_origin_shrink_3x3_by_1(rectangle(10, 10, 0, 3, 3), (1, 1), rectangle(11, 11, 0, 1, 1))]
+    #[case::away_from_origin_shrink_20x20_by_5(rectangle(10, 10, 0, 20, 20), (5, 5), rectangle(15, 15, 0, 10, 10))]
+    #[case::near_origin_shrink_30x30_by_5(rectangle(3, 3, 0, 30, 30), (5, 5), rectangle(8, 8, 0, 20, 20))]
+    fn validate_shrink_by(
+        #[case] initial: Rectangle,
+        #[case] margin: (usize, usize),
+        #[case] expected: Rectangle,
+    ) {
+        let actual = initial.shrink_by(margin.0, margin.1);
         assert_eq!(actual, expected);
     }
 }

--- a/src/tui/geometry.rs
+++ b/src/tui/geometry.rs
@@ -165,7 +165,7 @@ impl IntoIterator for Rectangle {
     fn into_iter(self) -> Self::IntoIter {
         let mut indices = Vec::new();
         if self.width() == 0 || self.height() == 0 {
-            return indices.into_iter()
+            return indices.into_iter();
         }
         for x in self.x()..(self.x() + self.width()) {
             for y in self.y()..(self.y() + self.height()) {
@@ -180,15 +180,8 @@ impl std::ops::Add for &Rectangle {
     type Output = Rectangle;
     fn add(self, other: &Rectangle) -> Self::Output {
         Rectangle(
-            Idx(
-                other.0.0,
-                other.0.1,
-                other.0.2,
-            ),
-            Bounds2D(
-                self.1.0 + other.1.0,
-                self.1.1 + other.1.1,
-            )
+            Idx(other.0 .0, other.0 .1, other.0 .2),
+            Bounds2D(self.1 .0 + other.1 .0, self.1 .1 + other.1 .1),
         )
     }
 }

--- a/src/tui/geometry.rs
+++ b/src/tui/geometry.rs
@@ -176,6 +176,23 @@ impl IntoIterator for Rectangle {
     }
 }
 
+impl std::ops::Add for &Rectangle {
+    type Output = Rectangle;
+    fn add(self, other: &Rectangle) -> Self::Output {
+        Rectangle(
+            Idx(
+                other.0.0,
+                other.0.1,
+                other.0.2,
+            ),
+            Bounds2D(
+                self.1.0 + other.1.0,
+                self.1.1 + other.1.1,
+            )
+        )
+    }
+}
+
 pub(crate) enum Position {
     TopLeft,
     TopRight,

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -7,3 +7,4 @@ pub(crate) mod crossterm;
 pub(crate) mod error;
 pub(crate) mod events;
 pub(crate) mod renderer;
+pub(crate) mod textbuffer;

--- a/src/tui/textbuffer.rs
+++ b/src/tui/textbuffer.rs
@@ -1,0 +1,214 @@
+use std::cmp::Ordering;
+use std::sync::mpsc::Sender;
+use std::sync::{Arc, Mutex, MutexGuard};
+
+use textwrap::wrap;
+
+use super::canvas::{Canvas, Modifier};
+use super::colors::Rgb;
+use super::drawbuffer::{DrawBufferInner, DrawBufferOwner};
+use super::error::{InnerError, Result};
+use super::geometry::{Position, Rectangle};
+use super::tuxel::Tuxel;
+
+#[derive(Clone, Default, PartialEq)]
+pub(crate) enum HAlignment {
+    Left,
+    #[default]
+    Center,
+    Right,
+}
+
+#[derive(Clone, Default, PartialEq)]
+pub(crate) enum VAlignment {
+    Top,
+    #[default]
+    Middle,
+    Bottom,
+}
+
+#[derive(Clone, Default, PartialEq)]
+pub(crate) struct FormatOptions {
+    halign: HAlignment,
+    valign: VAlignment,
+}
+
+pub(crate) struct CharBuf {
+    text: String,
+    fgcolor: Option<Rgb>,
+    bgcolor: Option<Rgb>,
+}
+
+impl CharBuf {
+    fn wrap(&self, width: usize) -> Vec<CharBuf> {
+        wrap(&self.text, width)
+            .into_iter()
+            .map(|s| CharBuf {
+                text: s.to_string(),
+                fgcolor: self.fgcolor.clone(),
+                bgcolor: self.bgcolor.clone(),
+            })
+            .collect()
+    }
+
+    #[inline]
+    fn len(&self) -> usize {
+        self.text.len()
+    }
+}
+
+/// A line-oriented buffer that makes writing structured/formatted text to DrawBuffers somewhat
+/// easier.
+pub(crate) struct TextBuffer {
+    bufs: Vec<CharBuf>,
+    inner: Arc<Mutex<DrawBufferInner>>,
+    format: FormatOptions,
+    sender: Sender<Tuxel>,
+}
+
+impl TextBuffer {
+    pub(crate) fn new(sender: Sender<Tuxel>, rectangle: Rectangle, canvas: Canvas) -> Self {
+        let mut buf: Vec<_> = Vec::with_capacity(rectangle.height());
+        for _ in 0..rectangle.height() {
+            let row: Vec<Tuxel> = Vec::with_capacity(rectangle.width());
+            buf.push(row);
+        }
+        Self {
+            bufs: Vec::new(),
+            inner: Arc::new(Mutex::new(DrawBufferInner {
+                rectangle,
+                border: false,
+                buf,
+                modifiers: Vec::new(),
+                canvas,
+            })),
+            format: FormatOptions::default(),
+            sender,
+        }
+    }
+
+    pub fn format(&mut self, format: &FormatOptions) {
+        if &self.format == format {
+            return;
+        }
+        self.format = format.clone()
+    }
+
+    pub fn write(&mut self, s: &str, fgcolor: Option<Rgb>, bgcolor: Option<Rgb>) {
+        self.bufs.push(CharBuf {
+            text: s.to_string(),
+            fgcolor,
+            bgcolor,
+        })
+    }
+
+    pub fn flush(&mut self) -> Result<()> {
+        let mut inner = self.lock();
+        let mut rect = inner.rectangle.clone();
+        if inner.border {
+            rect = rect.shrink_by(1, 1);
+        }
+
+        if rect.width() == 0 || rect.height() == 0 {
+            return Ok(())
+        }
+
+        let bufs = self
+            .bufs
+            .iter()
+            .map(|cb| cb.wrap(rect.width()))
+            .flatten()
+            .collect::<Vec<CharBuf>>();
+
+        let (mut y_index, buf_skip) = match (&self.format.valign, bufs.len().cmp(&rect.height())) {
+            (VAlignment::Top, _) => (0usize, 0usize),
+            (_, Ordering::Equal) => (0usize, 0usize),
+            (VAlignment::Middle, Ordering::Less) => {
+                let difference = rect.height() - bufs.len();
+                let y_index = difference / 2;
+                (y_index, 0)
+            }
+            (VAlignment::Middle, Ordering::Greater) => {
+                let difference = bufs.len() - rect.height();
+                let buf_skip = difference / 2;
+                (0, buf_skip)
+            }
+            (VAlignment::Bottom, Ordering::Less) => {
+                let y_index = rect.height() - bufs.len();
+                (y_index, 0)
+            }
+            (VAlignment::Bottom, Ordering::Greater) => {
+                let buf_skip = bufs.len() - rect.height();
+                (0, buf_skip)
+            }
+        };
+
+        let bufs_iter = bufs.iter().skip(buf_skip);
+
+        for charbuf in bufs_iter {
+            let buflen = charbuf.len();
+
+            if y_index > rect.height() {
+                // can't write beyond the bottom of the rectangle
+                break
+            }
+
+            let width_diff = if buflen > rect.width() {
+                // we shouldn't reach this point because we wrapped on the rectangle width earlier.
+                return Err(InnerError::OutOfBoundsX(buflen).into())
+            } else {
+                rect.width() - buflen
+            };
+
+            let x_index = match &self.format.halign {
+                HAlignment::Left => 0,
+                HAlignment::Center => width_diff/2,
+                HAlignment::Right => width_diff,
+            };
+
+            for (offset, c) in charbuf.text.chars().enumerate() {
+                let pos = Position::Coordinates(x_index + offset, y_index);
+                let tuxel = inner.get_tuxel_mut(pos)?;
+                tuxel.set_content(c);
+                if let Some(c) = &charbuf.bgcolor {
+                    tuxel.set_bgcolor(c.clone());
+                }
+                if let Some(c) = &charbuf.fgcolor {
+                    tuxel.set_fgcolor(c.clone());
+                }
+            }
+            
+            y_index += 1;
+        }
+
+        Ok(())
+    }
+}
+
+impl DrawBufferOwner for TextBuffer {
+    fn lock<'a>(&'a self) -> MutexGuard<'a, DrawBufferInner> {
+        self.inner
+            .as_ref()
+            .lock()
+            .expect("TODO: handle thread panicking better than this")
+    }
+
+    fn inner(&self) -> Arc<Mutex<DrawBufferInner>> {
+        self.inner.clone()
+    }
+}
+
+impl Drop for TextBuffer {
+    fn drop(&mut self) {
+        let mut inner = self.lock();
+        for row in inner.buf.iter_mut() {
+            while let Some(mut tuxel) = row.pop() {
+                tuxel.clear();
+                // can't do anything about send errors here -- we rely on the channel having the
+                // necessary capacity and the Canvas outliving all DrawBuffers
+                let _ = self.sender.send(tuxel);
+            }
+        }
+        let _ = inner.canvas.reclaim();
+    }
+}

--- a/src/tui/textbuffer.rs
+++ b/src/tui/textbuffer.rs
@@ -110,7 +110,7 @@ impl TextBuffer {
         }
 
         if rect.width() == 0 || rect.height() == 0 {
-            return Ok(())
+            return Ok(());
         }
 
         let bufs = self
@@ -150,19 +150,19 @@ impl TextBuffer {
 
             if y_index > rect.height() {
                 // can't write beyond the bottom of the rectangle
-                break
+                break;
             }
 
             let width_diff = if buflen > rect.width() {
                 // we shouldn't reach this point because we wrapped on the rectangle width earlier.
-                return Err(InnerError::OutOfBoundsX(buflen).into())
+                return Err(InnerError::OutOfBoundsX(buflen).into());
             } else {
                 rect.width() - buflen
             };
 
             let x_index = match &self.format.halign {
                 HAlignment::Left => 0,
-                HAlignment::Center => width_diff/2,
+                HAlignment::Center => width_diff / 2,
                 HAlignment::Right => width_diff,
             };
 
@@ -177,7 +177,7 @@ impl TextBuffer {
                     tuxel.set_fgcolor(c.clone());
                 }
             }
-            
+
             y_index += 1;
         }
 
@@ -186,7 +186,7 @@ impl TextBuffer {
 }
 
 #[cfg(test)]
-impl TextBuffer{
+impl TextBuffer {
     pub(crate) fn set_sender(&mut self, sender: Sender<Tuxel>) {
         self.sender = sender
     }

--- a/src/tui/textbuffer.rs
+++ b/src/tui/textbuffer.rs
@@ -185,6 +185,13 @@ impl TextBuffer {
     }
 }
 
+#[cfg(test)]
+impl TextBuffer{
+    pub(crate) fn set_sender(&mut self, sender: Sender<Tuxel>) {
+        self.sender = sender
+    }
+}
+
 impl DrawBufferOwner for TextBuffer {
     fn lock<'a>(&'a self) -> MutexGuard<'a, DrawBufferInner> {
         self.inner

--- a/src/tui/textbuffer.rs
+++ b/src/tui/textbuffer.rs
@@ -125,7 +125,7 @@ impl TextBuffer {
             (_, Ordering::Equal) => (0usize, 0usize),
             (VAlignment::Middle, Ordering::Less) => {
                 let difference = rect.height() - bufs.len();
-                let y_index = difference / 2;
+                let y_index = difference / 2 + difference % 2;
                 (y_index, 0)
             }
             (VAlignment::Middle, Ordering::Greater) => {
@@ -162,7 +162,7 @@ impl TextBuffer {
 
             let x_index = match &self.format.halign {
                 HAlignment::Left => 0,
-                HAlignment::Center => width_diff / 2,
+                HAlignment::Center => width_diff / 2 + width_diff % 2,
                 HAlignment::Right => width_diff,
             };
 
@@ -222,8 +222,6 @@ impl Drop for TextBuffer {
 
 #[cfg(test)]
 mod test {
-    use std::sync::mpsc::channel;
-
     use rstest::*;
 
     use super::super::geometry::{Bounds2D, Idx, Rectangle};
@@ -310,6 +308,155 @@ mod test {
         "          ",
         "      meow",
     ]))]
+    #[case::wrapping_default(None, "meowmeowmeow", from_strs(vec![
+        "          ",
+        "          ",
+        "meowmeowme",
+        "    ow    ",
+        "          ",
+    ]))]
+    #[case::wrapping_center_middle(fo(HAlignment::Center, VAlignment::Middle), "meowmeowmeow", from_strs(vec![
+        "          ",
+        "          ",
+        "meowmeowme",
+        "    ow    ",
+        "          ",
+    ]))]
+    #[case::wrapping_center_top(fo(HAlignment::Center, VAlignment::Top), "meowmeowmeow", from_strs(vec![
+        "meowmeowme",
+        "    ow    ",
+        "          ",
+        "          ",
+        "          ",
+    ]))]
+    #[case::wrapping_center_bottom(fo(HAlignment::Center, VAlignment::Bottom), "meowmeowmeow", from_strs(vec![
+        "          ",
+        "          ",
+        "          ",
+        "meowmeowme",
+        "    ow    ",
+    ]))]
+    #[case::wrapping_left_middle(fo(HAlignment::Left, VAlignment::Middle), "meowmeowmeow", from_strs(vec![
+        "          ",
+        "          ",
+        "meowmeowme",
+        "ow        ",
+        "          ",
+    ]))]
+    #[case::wrapping_left_top(fo(HAlignment::Left, VAlignment::Top), "meowmeowmeow", from_strs(vec![
+        "meowmeowme",
+        "ow        ",
+        "          ",
+        "          ",
+        "          ",
+    ]))]
+    #[case::wrapping_left_bottom(fo(HAlignment::Left, VAlignment::Bottom), "meowmeowmeow", from_strs(vec![
+        "          ",
+        "          ",
+        "          ",
+        "meowmeowme",
+        "ow        ",
+    ]))]
+    #[case::wrapping_right_middle(fo(HAlignment::Right, VAlignment::Middle), "meowmeowmeow", from_strs(vec![
+        "          ",
+        "          ",
+        "meowmeowme",
+        "        ow",
+        "          ",
+    ]))]
+    #[case::wrapping_right_top(fo(HAlignment::Right, VAlignment::Top), "meowmeowmeow", from_strs(vec![
+        "meowmeowme",
+        "        ow",
+        "          ",
+        "          ",
+        "          ",
+    ]))]
+    #[case::wrapping_right_bottom(fo(HAlignment::Right, VAlignment::Bottom), "meowmeowmeow", from_strs(vec![
+        "          ",
+        "          ",
+        "          ",
+        "meowmeowme",
+        "        ow",
+    ]))]
+    #[case::wrapping_multiword_default(None, "meow meow meow", from_strs(vec![
+        "          ",
+        "          ",
+        " meow meow",
+        "   meow   ",
+        "          ",
+    ]))]
+    #[case::wrapping_multiword_center_middle(fo(HAlignment::Center, VAlignment::Middle),
+                                             "meow meow meow", from_strs(vec![
+        "          ",
+        "          ",
+        " meow meow",
+        "   meow   ",
+        "          ",
+    ]))]
+    #[case::wrapping_multiword_center_top(fo(HAlignment::Center, VAlignment::Top),
+                                             "meow meow meow", from_strs(vec![
+        " meow meow",
+        "   meow   ",
+        "          ",
+        "          ",
+        "          ",
+    ]))]
+    #[case::wrapping_multiword_center_bottom(fo(HAlignment::Center, VAlignment::Bottom),
+                                             "meow meow meow", from_strs(vec![
+        "          ",
+        "          ",
+        "          ",
+        " meow meow",
+        "   meow   ",
+    ]))]
+    #[case::wrapping_multiword_left_middle(fo(HAlignment::Left, VAlignment::Middle),
+                                             "meow meow meow", from_strs(vec![
+        "          ",
+        "          ",
+        "meow meow ",
+        "meow      ",
+        "          ",
+    ]))]
+    #[case::wrapping_multiword_left_top(fo(HAlignment::Left, VAlignment::Top),
+                                             "meow meow meow", from_strs(vec![
+        "meow meow ",
+        "meow      ",
+        "          ",
+        "          ",
+        "          ",
+    ]))]
+    #[case::wrapping_multiword_left_bottom(fo(HAlignment::Left, VAlignment::Bottom),
+                                             "meow meow meow", from_strs(vec![
+        "          ",
+        "          ",
+        "          ",
+        "meow meow ",
+        "meow      ",
+    ]))]
+    #[case::wrapping_multiword_right_middle(fo(HAlignment::Right, VAlignment::Middle),
+                                             "meow meow meow", from_strs(vec![
+        "          ",
+        "          ",
+        " meow meow",
+        "      meow",
+        "          ",
+    ]))]
+    #[case::wrapping_multiword_right_top(fo(HAlignment::Right, VAlignment::Top),
+                                             "meow meow meow", from_strs(vec![
+        " meow meow",
+        "      meow",
+        "          ",
+        "          ",
+        "          ",
+    ]))]
+    #[case::wrapping_multiword_right_bottom(fo(HAlignment::Right, VAlignment::Bottom),
+                                             "meow meow meow", from_strs(vec![
+        "          ",
+        "          ",
+        "          ",
+        " meow meow",
+        "      meow",
+    ]))]
     fn validate_formatting_no_border(
         #[case] fo: Option<FormatOptions>,
         #[case] text: &str,
@@ -341,7 +488,16 @@ mod test {
                     .ok_or(InnerError::OutOfBoundsX(idx.x()))?
                     .clone();
                 let actual = t.content();
-                assert_eq!(actual, expected);
+                assert_eq!(
+                    actual,
+                    expected,
+                    "expected char '{}' at ({}, {}), got '{}'\nactual drawbuffer:\n{}",
+                    expected,
+                    idx.x(),
+                    idx.y(),
+                    actual,
+                    inner,
+                );
             }
         }
 

--- a/src/tui/textbuffer.rs
+++ b/src/tui/textbuffer.rs
@@ -29,8 +29,8 @@ pub(crate) enum VAlignment {
 
 #[derive(Clone, Default, PartialEq)]
 pub(crate) struct FormatOptions {
-    halign: HAlignment,
-    valign: VAlignment,
+    pub halign: HAlignment,
+    pub valign: VAlignment,
 }
 
 pub(crate) struct CharBuf {
@@ -98,6 +98,12 @@ impl TextBuffer {
             return;
         }
         self.format = format
+    }
+
+    pub fn clear(&mut self) -> Result<()> {
+        self.bufs = Vec::new();
+        self.fill(' ')?;
+        Ok(())
     }
 
     pub fn write(&mut self, s: &str, fgcolor: Option<Rgb>, bgcolor: Option<Rgb>) {

--- a/src/tui/tuxel.rs
+++ b/src/tui/tuxel.rs
@@ -32,6 +32,14 @@ impl Tuxel {
             .expect("idx sender has a big buffer, it shouldn't fail");
     }
 
+    pub(crate) fn set_bgcolor(&mut self, color: Rgb) {
+        self.bgcolor = Some(color);
+    }
+
+    pub(crate) fn set_fgcolor(&mut self, color: Rgb) {
+        self.fgcolor = Some(color);
+    }
+
     pub(crate) fn clear(&mut self) {
         self.active = false;
         self.content = ' ';

--- a/src/tui48.rs
+++ b/src/tui48.rs
@@ -10,7 +10,7 @@ use crate::engine::round::{AnimationHint, Hint};
 
 use super::error::{Error, Result};
 use crate::tui::canvas::{Canvas, Modifier};
-use crate::tui::drawbuffer::DrawBuffer;
+use crate::tui::drawbuffer::{DrawBufferOwner, DrawBuffer};
 use crate::tui::error::InnerError as TuiError;
 use crate::tui::events::{Event, EventSource, UserInput};
 use crate::tui::geometry::{Bounds2D, Direction, Idx, Rectangle};

--- a/src/tui48.rs
+++ b/src/tui48.rs
@@ -54,7 +54,7 @@ use crate::tui::renderer::Renderer;
 struct Tui48Board {
     canvas: Canvas,
     board: DrawBuffer,
-    score: DrawBuffer,
+    score: TextBuffer,
     slots: Vec<Vec<Slot>>,
     disappearing_slots: Vec<Slot>,
     moving_slots: Vec<Slot>,
@@ -83,7 +83,7 @@ impl Tui48Board {
         let mut board = canvas.get_draw_buffer(board_rectangle)?;
         board.draw_border()?;
 
-        let mut score = canvas.get_draw_buffer(score_rectangle)?;
+        let mut score = canvas.get_text_buffer(score_rectangle)?;
         Self::draw_score(&mut score, game.score())?;
 
         let (width, height) = game.dimensions();
@@ -193,10 +193,11 @@ impl Tui48Board {
         Ok(())
     }
 
-    fn draw_score(dbuf: &mut DrawBuffer, value: u16) -> Result<()> {
+    fn draw_score(dbuf: &mut TextBuffer, value: u16) -> Result<()> {
         dbuf.draw_border()?;
-        dbuf.fill(' ')?;
-        dbuf.write_right(&format!("{}", value))?;
+        dbuf.clear()?;
+        dbuf.write(&format!("{}", value), None, None);
+        dbuf.flush()?;
         dbuf.modify(Modifier::SetBackgroundColor(75, 50, 25));
         dbuf.modify(Modifier::SetForegroundColor(0, 0, 0));
         dbuf.modify(Modifier::SetFGLightness(0.2));

--- a/src/tui48.rs
+++ b/src/tui48.rs
@@ -965,7 +965,9 @@ impl<R: Renderer, E: EventSource> Tui48<R, E> {
             let board_rectangle = tui_board.board.rectangle();
             let message_rectangle = board_rectangle.shrink_by(5, 8);
             let mut buf = self.canvas.get_text_buffer(message_rectangle)?;
-            buf.write_left("game over! press 'q' to quit or 'n' to start new game")?;
+            buf.clear()?;
+            buf.write("game over! press 'q' to quit or 'n' to start new game", None, None);
+            buf.flush()?;
             self.renderer.render(&self.canvas)?;
             match self.event_source.next_event()? {
                 Event::UserInput(UserInput::Direction(d)) => {
@@ -991,8 +993,13 @@ impl<R: Renderer, E: EventSource> Tui48<R, E> {
     fn run_terminal_too_small(&mut self) -> Result<GameState> {
         self.renderer.clear(&self.canvas)?;
         loop {
-            let mut buf = self.canvas.get_layer(7)?;
-            buf.write_left("the terminal is too small, please make it bigger!")?;
+            let (c_width, c_height) = self.canvas.dimensions();
+            let canvas_rectangle = Rectangle(Idx(0,0,0), Bounds2D(c_width, c_height));
+            let message_rectangle = canvas_rectangle.shrink_by(2, 2);
+            let mut buf = self.canvas.get_text_buffer(message_rectangle)?;
+            buf.clear()?;
+            buf.write("the terminal is too small, please make it bigger!", None, None);
+            buf.flush()?;
             self.renderer.render(&self.canvas)?;
             match self.event_source.next_event()? {
                 Event::Resize => {

--- a/src/tui48.rs
+++ b/src/tui48.rs
@@ -121,8 +121,9 @@ impl Tui48Board {
     fn get_validated_dimensions(canvas_width: usize, canvas_height: usize) -> Result<(Rectangle, Rectangle)> {
         let board_rectangle = Self::board_rectangle();
         let score_rectangle = Rectangle(Idx(18, 1, BOARD_LAYER_IDX), Bounds2D(10, 3));
+        let board_rectangle_with_tile_start = board_rectangle.expand_by(3);
 
-        let combined_rectangle = &board_rectangle + &score_rectangle;
+        let combined_rectangle = &board_rectangle_with_tile_start + &score_rectangle;
         let (x_extent, y_extent) = combined_rectangle.extents();
 
         if canvas_width < x_extent || canvas_height < y_extent {


### PR DESCRIPTION
@SteveLasker reported several bugs via PM, including:

# terminal size bug

`tui48` currently performs bounds checking (ie check that the `Canvas` and the
terminal emulator are large enough) on the static elements of the UI, but
doesn't take into account the bounds implied by the path of new tiles as they
are created and animated into their position (aka the "dynamic bounds"). This
usually looks something like the following:

```
Error: OutOfBoundsY(33)
disabled backtrace

Caused by:
    out of bounds y: 33
    disabled backtrace
```

This happens specifically when the terminal size is between the static bounds
of the UI and its dynamic bounds. If it's smaller than the static bounds
`tui48` shows a helpful message and if it's larger than the dynamic bounds
everything works fine.

This PR addresses this bug with some refactors and improvements in the
`tui::geometry::Rectangle` type.

# game over state handling

Refactor `tui48`'s game loop into something like a state machine to handle the
different states the game can end up in:

* `GameState::Active` - normal game play state
* `GameState::Over` - no more moves are possible, ask player how to proceed
* `GameState::Reset` - reset the game board to a new randomized initial state
    to start game play over again
* `GameState::TerminalTooSmall` - the terminal is too small, let the player
    know they need to resize to continue
* `GameState::Quit` - end game play

Previously the "terminal too small" input handling was neglegently mixed in
with active game play input handling meaning that while the user was unable to
see the board they could potentially blindly slide tiles with the active game
play inputs. The new state machine approach prevents this from happening.

This also introduces a "reset" handling state; previously if a player wanted to
reset gameplay they would have to quit the game and start a new instance.
