### PR TITLE
support full range of 2048 tile values

### DIFF
--- a/src/engine/round.rs
+++ b/src/engine/round.rs
@@ -170,7 +170,7 @@ impl Round {
                 // do so and increment the score by the value of the eliminated element
                 if pivot == cmp {
                     let new_value = pivot + cmp;
-                    self.score += cmp as u32;
+                    self.score += new_value as u32;
                     self.set(pivot_idx, pivot + cmp);
                     self.set(cmp_idx, 0);
                     hint.set(cmp_idx, Hint::NewValueToIdx(new_value, pivot_idx.clone()));
@@ -445,22 +445,22 @@ mod test {
     #[case::all1s(
         Direction::Left,
         round([[1, 1, 1, 1], [0, 0, 0, 0], [0, 0, 0, 0], [0, 0, 0, 0]], 0),
-        round([[2, 2, 0, 2], [0, 0, 0, 0], [0, 0, 0, 0], [0, 0, 0, 0]], 2),
+        round([[2, 2, 0, 2], [0, 0, 0, 0], [0, 0, 0, 0], [0, 0, 0, 0]], 4),
     )]
     #[case::combine2s_shift_remaining(
         Direction::Left,
         round([[2, 2, 0, 2], [0, 0, 0, 0], [0, 0, 0, 0], [0, 0, 0, 0]], 2),
-        round([[4, 2, 0, 2], [0, 0, 0, 0], [0, 0, 0, 0], [0, 0, 0, 0]], 4),
+        round([[4, 2, 0, 2], [0, 0, 0, 0], [0, 0, 0, 0], [0, 0, 0, 0]], 6),
     )]
     #[case::combine2s_shift_remaining(
         Direction::Left,
         round([[2, 0, 2, 2], [0, 0, 0, 0], [0, 0, 0, 0], [0, 0, 0, 0]], 2),
-        round([[4, 2, 0, 2], [0, 0, 0, 0], [0, 0, 0, 0], [0, 0, 0, 0]], 4),
+        round([[4, 2, 0, 2], [0, 0, 0, 0], [0, 0, 0, 0], [0, 0, 0, 0]], 6),
     )]
     #[case::combine2s_ignore_4(
         Direction::Left,
         round([[4, 2, 0, 2], [0, 0, 0, 0], [0, 0, 0, 0], [0, 0, 0, 0]], 4),
-        round([[4, 4, 0, 2], [0, 0, 0, 0], [0, 0, 0, 0], [0, 0, 0, 0]], 6),
+        round([[4, 4, 0, 2], [0, 0, 0, 0], [0, 0, 0, 0], [0, 0, 0, 0]], 8),
     )]
     #[case::noop_no_compatible_combinations(
         Direction::Left,
@@ -470,17 +470,17 @@ mod test {
     #[case::all1s_right(
         Direction::Right,
         round([[1, 1, 1, 1], [0, 0, 0, 0], [0, 0, 0, 0], [0, 0, 0, 0]], 0),
-        round([[2, 0, 2, 2], [0, 0, 0, 0], [0, 0, 0, 0], [0, 0, 0, 0]], 2),
+        round([[2, 0, 2, 2], [0, 0, 0, 0], [0, 0, 0, 0], [0, 0, 0, 0]], 4),
     )]
     #[case::combine2s_shift_remaining_right(
         Direction::Right,
         round([[2, 2, 0, 2], [0, 0, 0, 0], [0, 0, 0, 0], [0, 0, 0, 0]], 2),
-        round([[2, 0, 2, 4], [0, 0, 0, 0], [0, 0, 0, 0], [0, 0, 0, 0]], 4),
+        round([[2, 0, 2, 4], [0, 0, 0, 0], [0, 0, 0, 0], [0, 0, 0, 0]], 6),
     )]
     #[case::combine2s_ignore_4_right(
         Direction::Right,
         round([[4, 2, 0, 2], [0, 0, 0, 0], [0, 0, 0, 0], [0, 0, 0, 0]], 4),
-        round([[2, 0, 4, 4], [0, 0, 0, 0], [0, 0, 0, 0], [0, 0, 0, 0]], 6),
+        round([[2, 0, 4, 4], [0, 0, 0, 0], [0, 0, 0, 0], [0, 0, 0, 0]], 8),
     )]
     #[case::noop_no_compatible_combinations_right(
         Direction::Right,

--- a/src/engine/round.rs
+++ b/src/engine/round.rs
@@ -89,7 +89,7 @@ impl AnimationHint {
 
 pub(crate) type Card = u16;
 
-pub(crate) type Score = u16;
+pub(crate) type Score = u32;
 
 const NEW_CARD_CHOICES: [u16; 2] = [2, 4];
 const NEW_CARD_WEIGHTS: [u8; 2] = [9, 1];
@@ -170,7 +170,7 @@ impl Round {
                 // do so and increment the score by the value of the eliminated element
                 if pivot == cmp {
                     let new_value = pivot + cmp;
-                    self.score += cmp;
+                    self.score += cmp as u32;
                     self.set(pivot_idx, pivot + cmp);
                     self.set(cmp_idx, 0);
                     hint.set(cmp_idx, Hint::NewValueToIdx(new_value, pivot_idx.clone()));

--- a/src/tui48.rs
+++ b/src/tui48.rs
@@ -788,6 +788,7 @@ struct Colors {
 }
 
 static DEFAULT_COLORS: OnceLock<Colors> = OnceLock::new();
+static MAX_TILE_EXPONENT: u8 = 17;
 
 pub(crate) fn init() -> Result<()> {
     if let Some(_) = DEFAULT_COLORS.get() {
@@ -798,13 +799,13 @@ pub(crate) fn init() -> Result<()> {
     let fg_hue = bg_hue + 180.0;
     let defaults = Colors {
         card_colors: HashMap::from_iter(
-            (0..11)
+            (0..MAX_TILE_EXPONENT)
                 .into_iter()
                 .map(|i| {
                     (
                         i,
-                        Lch::new(80.0, 90.0, i as f32 * 360.0 / 10.0),
-                        Lch::new(20.0, 50.0, fg_hue),
+                        Lch::new(80.0, 90.0 - (40.0 * ((i % 2) as f32)), i as f32 * 360.0 / MAX_TILE_EXPONENT as f32),
+                        Lch::new(20.0, 90.0 - (40.0 * (((i + 1) % 2) as f32)), fg_hue),
                     )
                 })
                 .map(|(k, bg_hsv, fg_hsv)| {

--- a/src/tui48.rs
+++ b/src/tui48.rs
@@ -160,7 +160,7 @@ impl Tui48Board {
         Ok(())
     }
 
-    fn draw_score(dbuf: &mut TextBuffer, value: u16) -> Result<()> {
+    fn draw_score(dbuf: &mut TextBuffer, value: u32) -> Result<()> {
         dbuf.draw_border()?;
         dbuf.clear()?;
         dbuf.write(&format!("{}", value), None, None);

--- a/src/tui48.rs
+++ b/src/tui48.rs
@@ -803,7 +803,7 @@ pub(crate) fn init() -> Result<()> {
 
     let defaults = Colors {
         card_colors: HashMap::from_iter(
-            (0..MAX_TILE_EXPONENT)
+            (1..MAX_TILE_EXPONENT)
                 .into_iter()
                 .map(|i| {
                     (

--- a/src/tui48.rs
+++ b/src/tui48.rs
@@ -795,8 +795,12 @@ pub(crate) fn init() -> Result<()> {
         // already set, no need to do anything else
         return Ok(());
     }
-    let bg_hue = 28.0;
-    let fg_hue = bg_hue + 180.0;
+    let fg_hue = 28.0 + 180.0;
+    let incr = |inc: u8, num: f32, div: u8| -> f32 { inc as f32 * num / div as f32 };
+    let bg_hue = |i: u8| -> f32 { incr(i, 360.0, MAX_TILE_EXPONENT) };
+    let bg_chroma = |i: u8| -> f32 { 30.0 + incr(i, 60.0, i) };
+    let fg_chroma = |i: u8| -> f32 { 90.0 - incr(i, 40.0, MAX_TILE_EXPONENT/2) };
+
     let defaults = Colors {
         card_colors: HashMap::from_iter(
             (0..MAX_TILE_EXPONENT)
@@ -804,8 +808,8 @@ pub(crate) fn init() -> Result<()> {
                 .map(|i| {
                     (
                         i,
-                        Lch::new(80.0, 90.0 - (40.0 * ((i % 2) as f32)), i as f32 * 360.0 / MAX_TILE_EXPONENT as f32),
-                        Lch::new(20.0, 90.0 - (40.0 * (((i + 1) % 2) as f32)), fg_hue),
+                        Lch::new(80.0, bg_chroma(i), bg_hue(i)),
+                        Lch::new(20.0, fg_chroma(i), fg_hue),
                     )
                 })
                 .map(|(k, bg_hsv, fg_hsv)| {

--- a/src/tui48.rs
+++ b/src/tui48.rs
@@ -10,12 +10,12 @@ use crate::engine::round::{AnimationHint, Hint};
 
 use super::error::{Error, Result};
 use crate::tui::canvas::{Canvas, Modifier};
-use crate::tui::textbuffer::{FormatOptions, HAlignment, VAlignment, TextBuffer};
 use crate::tui::drawbuffer::{DrawBuffer, DrawBufferOwner};
 use crate::tui::error::InnerError as TuiError;
 use crate::tui::events::{Event, EventSource, UserInput};
 use crate::tui::geometry::{Bounds2D, Direction, Idx, Rectangle};
 use crate::tui::renderer::Renderer;
+use crate::tui::textbuffer::{FormatOptions, HAlignment, TextBuffer, VAlignment};
 
 /// TUI representation of a 2048 game board.
 struct Tui48Board {
@@ -151,7 +151,7 @@ impl Tui48Board {
         dbuf.modify(colors.1);
         dbuf.draw_border()?;
         dbuf.clear()?;
-        dbuf.format(FormatOptions{
+        dbuf.format(FormatOptions {
             halign: HAlignment::Center,
             valign: VAlignment::Middle,
         });
@@ -938,7 +938,11 @@ impl<R: Renderer, E: EventSource> Tui48<R, E> {
             let message_rectangle = board_rectangle.shrink_by(5, 8);
             let mut buf = self.canvas.get_text_buffer(message_rectangle)?;
             buf.clear()?;
-            buf.write("game over! press 'q' to quit or 'n' to start new game", None, None);
+            buf.write(
+                "game over! press 'q' to quit or 'n' to start new game",
+                None,
+                None,
+            );
             buf.flush()?;
             self.renderer.render(&self.canvas)?;
             match self.event_source.next_event()? {
@@ -966,11 +970,15 @@ impl<R: Renderer, E: EventSource> Tui48<R, E> {
         self.renderer.clear(&self.canvas)?;
         loop {
             let (c_width, c_height) = self.canvas.dimensions();
-            let canvas_rectangle = Rectangle(Idx(0,0,0), Bounds2D(c_width, c_height));
+            let canvas_rectangle = Rectangle(Idx(0, 0, 0), Bounds2D(c_width, c_height));
             let message_rectangle = canvas_rectangle.shrink_by(2, 2);
             let mut buf = self.canvas.get_text_buffer(message_rectangle)?;
             buf.clear()?;
-            buf.write("the terminal is too small, please make it bigger!", None, None);
+            buf.write(
+                "the terminal is too small, please make it bigger!",
+                None,
+                None,
+            );
             buf.flush()?;
             self.renderer.render(&self.canvas)?;
             match self.event_source.next_event()? {

--- a/src/tui48.rs
+++ b/src/tui48.rs
@@ -17,40 +17,7 @@ use crate::tui::events::{Event, EventSource, UserInput};
 use crate::tui::geometry::{Bounds2D, Direction, Idx, Rectangle};
 use crate::tui::renderer::Renderer;
 
-/// Generates a 2048 TUI layout with legible numbers.
-///
-///  37
-///  ╔══════════════════════════════════╗
-///  ║                                  ║
-///  ║  xxxxxx  xxxxxx  xxxxxx  xxxxxx  ║
-///  ║  xxxxxx  xxxxxx  xxxxxx  xxxxxx  ║
-///  ║  xxxxxx  xxxxxx  xxxxxx  xxxxxx  ║
-///  ║  xxxxxx  xxxxxx  xxxxxx  xxxxxx  ║
-///  ║  xxxxxx  xxxxxx  xxxxxx  xxxxxx  ║
-///  ║                                  ║
-///  ║  xxxxxx  xxxxxx  xxxxxx  xxxxxx  ║
-///  ║  xxxxxx  xxxxxx  xxxxxx  xxxxxx  ║
-///  ║  xxxxxx  xxxxxx  xxxxxx  xxxxxx  ║
-///  ║  xxxxxx  xxxxxx  xxxxxx  xxxxxx  ║
-///  ║  xxxxxx  xxxxxx  xxxxxx  xxxxxx  ║
-///  ║                                  ║
-///  ║  xxxxxx  xxxxxx  xxxxxx  xxxxxx  ║
-///  ║  xxxxxx  xxxxxx  xxxxxx  xxxxxx  ║
-///  ║  xxxxxx  xxxxxx  xxxxxx  xxxxxx  ║
-///  ║  xxxxxx  xxxxxx  xxxxxx  xxxxxx  ║
-///  ║  xxxxxx  xxxxxx  xxxxxx  xxxxxx  ║
-///  ║                                  ║
-///  ║  xxxxxx  xxxxxx  xxxxxx  xxxxxx  ║
-///  ║  xxxxxx  xxxxxx  xxxxxx  xxxxxx  ║
-///  ║  xxxxxx  xxxxxx  xxxxxx  xxxxxx  ║
-///  ║  xxxxxx  xxxxxx  xxxxxx  xxxxxx  ║
-///  ║  xxxxxx  xxxxxx  xxxxxx  xxxxxx  ║
-///  ║                                  ║
-///  ╚══════════════════════════════════╝
-///  65
-///  6                                 42
-///
-///
+/// TUI representation of a 2048 game board.
 struct Tui48Board {
     canvas: Canvas,
     board: DrawBuffer,


### PR DESCRIPTION
This PR makes a few mostly invisible improvements:

## engine: update score calculation to mimic original 2048

Probably the most visible improvement, this updates the game engine's score
calculation so that when two tiles are combined the value of the newly-created
tile is added (rather than the pre-combination value of the tiles). For
example, if a two 2 tiles are combined into a 4 tile, the value 4 is added
rather than 2.

## engine: represent score with a u32

This should support the maximum possible 2048 score.

## engine/round: represent Card values as u8s

This optimizes memory usage and enables the maximum possible tile value to
trivially be possible.

## tui48: support tile colors up to max tile size

Previously we only supported 12 different tile colors, now we support 17.

## tui48: use closures to calculate bg_hue and {bg,fg}_chroma

Simplify the code a little, make it easier to experiment with new color
schemes.
